### PR TITLE
feat: schema and indexing for Morpho Blue contract

### DIFF
--- a/ponder.schema.ts
+++ b/ponder.schema.ts
@@ -1,6 +1,59 @@
-import { onchainTable } from "ponder";
+import { index, onchainTable, primaryKey, relations } from "ponder";
 
-export const example = onchainTable("example", (t) => ({
-  id: t.text().primaryKey(),
-  name: t.text(),
+export const market = onchainTable(
+  "market",
+  (t) => ({
+    chainId: t.integer().notNull(),
+    id: t.hex().notNull(),
+
+    // MarketParams fields
+    loanToken: t.hex().notNull(),
+    collateralToken: t.hex().notNull(),
+    oracle: t.hex().notNull(),
+    irm: t.hex().notNull(),
+    lltv: t.bigint().notNull(),
+
+    // Market fields
+    totalSupplyAssets: t.bigint().notNull().default(0n),
+    totalSupplyShares: t.bigint().notNull().default(0n),
+    totalBorrowAssets: t.bigint().notNull().default(0n),
+    totalBorrowShares: t.bigint().notNull().default(0n),
+    lastUpdate: t.bigint().notNull(),
+    fee: t.bigint().notNull().default(0n),
+  }),
+  (table) => ({
+    // Composite primary key uniquely identifies a market across chains
+    pk: primaryKey({ columns: [table.chainId, table.id] }),
+  })
+);
+
+export const marketRelations = relations(market, ({ many }) => ({
+  positions: many(position),
+}));
+
+export const position = onchainTable(
+  "position",
+  (t) => ({
+    chainId: t.integer().notNull(),
+    marketId: t.hex().notNull(),
+    user: t.hex().notNull(),
+
+    // Position fields
+    supplyShares: t.bigint().notNull().default(0n),
+    borrowShares: t.bigint().notNull().default(0n),
+    collateral: t.bigint().notNull().default(0n),
+  }),
+  (table) => ({
+    // Composite primary key uniquely identifies a position across chains
+    pk: primaryKey({ columns: [table.chainId, table.marketId, table.user] }),
+    // Index speeds up relational queries
+    marketIdx: index().on(table.chainId, table.marketId),
+  })
+);
+
+export const positionRelations = relations(position, ({ one }) => ({
+  market: one(market, {
+    fields: [position.chainId, position.marketId],
+    references: [market.chainId, market.id],
+  }),
 }));

--- a/src/MorphoBlue.ts
+++ b/src/MorphoBlue.ts
@@ -1,17 +1,185 @@
 import { ponder } from "ponder:registry";
+import { market, position } from "ponder:schema";
+
+ponder.on("Morpho:CreateMarket", async ({ event, context }) => {
+  // `CreateMarket` can only fire once for a given `{ chainId, id }`,
+  // so we can insert without any `onConflict` handling.
+  await context.db.insert(market).values({
+    // primary key
+    chainId: context.network.chainId,
+    id: event.args.id,
+    // `MarketParams` struct
+    loanToken: event.args.marketParams.loanToken,
+    collateralToken: event.args.marketParams.collateralToken,
+    oracle: event.args.marketParams.oracle,
+    irm: event.args.marketParams.irm,
+    lltv: event.args.marketParams.lltv,
+    // `Market` struct (unspecified fields default to 0n)
+    lastUpdate: event.block.timestamp,
+  });
+});
+
+ponder.on("Morpho:SetFee", async ({ event, context }) => {
+  // Row must exist because `SetFee` cannot preceed `CreateMarket`.
+  await context.db
+    .update(market, {
+      chainId: context.network.chainId,
+      id: event.args.id,
+    })
+    .set({ fee: event.args.newFee });
+});
 
 ponder.on("Morpho:AccrueInterest", async ({ event, context }) => {
-  console.log(event.args);
+  // Row must exist because `AccrueInterest` cannot preceed `CreateMarket`.
+  await context.db
+    .update(market, {
+      chainId: context.network.chainId,
+      id: event.args.id,
+    })
+    .set((row) => ({
+      totalSupplyAssets: row.totalSupplyAssets + event.args.interest,
+      totalSupplyShares: row.totalSupplyShares + event.args.feeShares,
+      totalBorrowAssets: row.totalBorrowAssets + event.args.interest,
+      lastUpdate: event.block.timestamp,
+    }));
+});
+
+ponder.on("Morpho:Supply", async ({ event, context }) => {
+  await Promise.all([
+    // Row must exist because `Supply` cannot preceed `CreateMarket`.
+    context.db
+      .update(market, { chainId: context.network.chainId, id: event.args.id })
+      .set((row) => ({
+        totalSupplyAssets: row.totalSupplyAssets + event.args.assets,
+        totalSupplyShares: row.totalSupplyShares + event.args.shares,
+      })),
+    // Row may or may not exist because `Supply` could be `user`'s first action.
+    context.db
+      .insert(position)
+      .values({
+        // primary key
+        chainId: context.network.chainId,
+        marketId: event.args.id,
+        user: event.args.onBehalf,
+        // `Position` struct (unspecified fields default to 0n)
+        supplyShares: event.args.shares,
+      })
+      .onConflictDoUpdate((row) => ({
+        supplyShares: row.supplyShares + event.args.shares,
+      })),
+  ]);
+});
+
+ponder.on("Morpho:Withdraw", async ({ event, context }) => {
+  await Promise.all([
+    // Row must exist because `Withdraw` cannot preceed `CreateMarket`.
+    context.db
+      .update(market, { chainId: context.network.chainId, id: event.args.id })
+      .set((row) => ({
+        totalSupplyAssets: row.totalSupplyAssets - event.args.assets,
+        totalSupplyShares: row.totalSupplyShares - event.args.shares,
+      })),
+    // Row must exist because `Withdraw` cannot preceed `Supply`.
+    context.db
+      .update(position, {
+        chainId: context.network.chainId,
+        marketId: event.args.id,
+        user: event.args.onBehalf,
+      })
+      .set((row) => ({ supplyShares: row.supplyShares - event.args.shares })),
+  ]);
+});
+
+ponder.on("Morpho:SupplyCollateral", async ({ event, context }) => {
+  // Row may or may not exist because `SupplyCollateral` could be `user`'s first action.
+  await context.db
+    .insert(position)
+    .values({
+      // primary key
+      chainId: context.network.chainId,
+      marketId: event.args.id,
+      user: event.args.onBehalf,
+      // `Position` struct (unspecified fields default to 0n)
+      collateral: event.args.assets,
+    })
+    .onConflictDoUpdate((row) => ({
+      collateral: row.collateral + event.args.assets,
+    }));
+});
+
+ponder.on("Morpho:WithdrawCollateral", async ({ event, context }) => {
+  // Row must exist because `WithdrawCollateral` cannot preceed `SupplyCollateral`.
+  await context.db
+    .update(position, {
+      chainId: context.network.chainId,
+      marketId: event.args.id,
+      user: event.args.onBehalf,
+    })
+    .set((row) => ({ collateral: row.collateral - event.args.assets }));
 });
 
 ponder.on("Morpho:Borrow", async ({ event, context }) => {
-  console.log(event.args);
+  await Promise.all([
+    // Row must exist because `Borrow` cannot preceed `CreateMarket`.
+    context.db
+      .update(market, { chainId: context.network.chainId, id: event.args.id })
+      .set((row) => ({
+        totalBorrowAssets: row.totalBorrowAssets + event.args.assets,
+        totalBorrowShares: row.totalBorrowShares + event.args.shares,
+      })),
+    // Row must exist because `Borrow` cannot preceed `SupplyCollateral`.
+    context.db
+      .update(position, {
+        chainId: context.network.chainId,
+        marketId: event.args.id,
+        user: event.args.onBehalf,
+      })
+      .set((row) => ({ borrowShares: row.borrowShares + event.args.shares })),
+  ]);
 });
 
-ponder.on("Morpho:CreateMarket", async ({ event, context }) => {
-  console.log(event.args);
+ponder.on("Morpho:Repay", async ({ event, context }) => {
+  await Promise.all([
+    // Row must exist because `Repay` cannot preceed `CreateMarket`.
+    context.db
+      .update(market, { chainId: context.network.chainId, id: event.args.id })
+      .set((row) => ({
+        totalBorrowAssets: row.totalBorrowAssets - event.args.assets,
+        totalBorrowShares: row.totalBorrowShares - event.args.shares,
+      })),
+    // Row must exist because `Repay` cannot preceed `SupplyCollateral`.
+    context.db
+      .update(position, {
+        chainId: context.network.chainId,
+        marketId: event.args.id,
+        user: event.args.onBehalf,
+      })
+      .set((row) => ({ borrowShares: row.borrowShares - event.args.shares })),
+  ]);
 });
 
-ponder.on("Morpho:EnableIrm", async ({ event, context }) => {
-  console.log(event.args);
+ponder.on("Morpho:Liquidate", async ({ event, context }) => {
+  await Promise.all([
+    // Row must exist because `Liquidate` cannot preceed `CreateMarket`.
+    context.db
+      .update(market, { chainId: context.network.chainId, id: event.args.id })
+      .set((row) => ({
+        totalSupplyAssets: row.totalSupplyAssets - event.args.badDebtAssets,
+        totalSupplyShares: row.totalSupplyAssets - event.args.badDebtShares,
+        totalBorrowAssets: row.totalBorrowAssets - event.args.repaidAssets,
+        totalBorrowShares: row.totalBorrowShares - event.args.repaidShares,
+      })),
+    // Row must exist because `Liquidate` cannot preceed `SupplyCollateral`.
+    context.db
+      .update(position, {
+        chainId: context.network.chainId,
+        marketId: event.args.id,
+        user: event.args.borrower,
+      })
+      .set((row) => ({
+        collateral: row.collateral - event.args.seizedAssets,
+        borrowShares:
+          row.borrowShares - event.args.repaidShares - event.args.badDebtShares,
+      })),
+  ]);
 });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,11 @@
+import { db } from "ponder:api";
+import schema from "ponder:schema";
+import { Hono } from "hono";
+import { graphql } from "ponder";
+
+const app = new Hono();
+
+app.use("/", graphql({ db, schema }));
+app.use("/graphql", graphql({ db, schema }));
+
+export default app;


### PR DESCRIPTION
In commit 7ef01e0e7a4fd7cb34c49a27d11c4c5fe2106f6f, ponder creates an example schema and placeholder indexing functions. Here I add a real schema and real indexing.

We discussed splitting up `market` and `marketParams` into separate tables to match the contracts. I tried this, and while it makes GraphQL `positions` queries slightly more Solidity-like, it makes `market` and `marketParams` queries significantly more awkward. For example, if you’re looking for them by token address or filtering by oracle, you have to specify filters on both, as opposed to just once -- resulting in duplicate code. Since there's no harm in a unified table, I think we should stick with that.