### PR TITLE
feat: example @ponder/client usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Dependencies
 **/node_modules
 
+**/dist
+
 # Debug
 npm-debug.log*
 yarn-debug.log*

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -3,6 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
+  "scripts": {
+    "dev": "tsc && concurrently \"tsc --watch\" \"node dist/client/src/index.js\"",
+    "lint": "eslint . --fix",
+    "typecheck": "tsc --noEmit"
+  },
   "dependencies": {
     "@ponder/client": "^0.9.27"
   }

--- a/apps/client/src/index.ts
+++ b/apps/client/src/index.ts
@@ -1,0 +1,9 @@
+import { createClient } from "@ponder/client";
+
+import * as schema from "../../ponder/ponder.schema.js";
+
+const client = createClient("http://localhost:42069/sql", { schema });
+
+const result = await client.db.select().from(schema.vault).limit(10);
+
+console.log(result);

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "../../tsconfig",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist"
+  },
   "include": ["./**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/apps/ponder/package.json
+++ b/apps/ponder/package.json
@@ -12,8 +12,6 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "hono": "^4.5.0",
-    "ponder": "^0.9.19",
-    "viem": "^2.21.3"
+    "hono": "^4.5.0"
   }
 }

--- a/apps/ponder/src/api/index.ts
+++ b/apps/ponder/src/api/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { graphql } from "ponder";
+import { client, graphql } from "ponder";
 import { db } from "ponder:api";
 import schema from "ponder:schema";
 
@@ -7,5 +7,6 @@ const app = new Hono();
 
 app.use("/", graphql({ db, schema }));
 app.use("/graphql", graphql({ db, schema }));
+app.use("/sql/*", client({ db, schema }));
 
 export default app;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
       "eslint --fix"
     ]
   },
+  "dependencies": {
+    "ponder": "^0.9.19",
+    "viem": "^2.21.3"
+  },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
     "@types/node": "^20.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,13 @@ settings:
 importers:
 
   .:
+    dependencies:
+      ponder:
+        specifier: ^0.9.19
+        version: 0.9.19(@opentelemetry/api@1.9.0)(@types/node@20.17.17)(hono@4.7.0)(typescript@5.7.3)(viem@2.23.0(typescript@5.7.3))
+      viem:
+        specifier: ^2.21.3
+        version: 2.23.0(typescript@5.7.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.20.0
@@ -59,12 +66,6 @@ importers:
       hono:
         specifier: ^4.5.0
         version: 4.7.0
-      ponder:
-        specifier: ^0.9.19
-        version: 0.9.19(@opentelemetry/api@1.9.0)(@types/node@20.17.17)(hono@4.7.0)(typescript@5.7.3)(viem@2.23.0(typescript@5.7.3))
-      viem:
-        specifier: ^2.21.3
-        version: 2.23.0(typescript@5.7.3)
 
 packages:
 


### PR DESCRIPTION
Builds on top of the monorepo to provide example SQL client usage.

Note I had to move `ponder` dependency back to root of monorepo due to the relative import of the ponder.schema.ts. This is recommended in their docs, but seems suboptimal. May have Claude Code try to fix later, but things are working for now!