### PR TITLE
feat: example api endpoint for vault->markets

### DIFF
--- a/apps/ponder/src/api/index.ts
+++ b/apps/ponder/src/api/index.ts
@@ -1,12 +1,27 @@
 import { Hono } from "hono";
-import { client, graphql } from "ponder";
+import { and, client, eq, graphql } from "ponder";
 import { db } from "ponder:api";
 import schema from "ponder:schema";
+import { Address } from "viem";
 
 const app = new Hono();
 
 app.use("/", graphql({ db, schema }));
 app.use("/graphql", graphql({ db, schema }));
 app.use("/sql/*", client({ db, schema }));
+
+app.get("/chain/:id/vault/:address", async (c) => {
+  const { id: chainId, address } = c.req.param();
+
+  const vault = await db
+    .select()
+    .from(schema.vault)
+    .where(
+      and(eq(schema.vault.chainId, Number(chainId)), eq(schema.vault.address, address as Address)),
+    )
+    .limit(1);
+
+  return c.json(vault[0]?.withdrawQueue);
+});
 
 export default app;


### PR DESCRIPTION
Builds on top of the monorepo to provide an example API endpoint in the ponder service.

This is an alternative to the direct SQL client usage shown in #4. The client app would do a simple http fetch rather than a fancy SQL query. We can use whatever is easiest for a given situation.