### PR TITLE
Update README.md to clone the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use at your own risk.
 ## Installation
 
 ```bash
-git clone https://github.com/morpho-blue-liquidation-bot-org/morpho-blue-liquidation-bot.git
+git clone https://github.com/morpho-org/morpho-blue-liquidation-bot.git
 cd morpho-blue-liquidation-bot
 pnpm install
 ```


### PR DESCRIPTION
git clone git clone https://github.com/morpho-blue-liquidation-bot-org/morpho-blue-liquidation-bot.git didn't work as the repo lives under morpho-org, not morpho-blue-liquidation-bot-org. Update it with 
git clone https://github.com/morpho-org/morpho-blue-liquidation-bot.git
