### PR TITLE
fix: improve container stability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ Workspace monorepo with six packages:
    - `chain` — the viem Chain object
    - `wNative` — wrapped native token address
    - `options` — vault whitelist, liquidity venues (ordered), pricers (ordered), buffer, flashbots toggle, block interval
+   - `watchBlocksRetryDelayMs` — delay in ms before restarting the block watcher after an RPC error (default: 5000)
 3. Set up environment variables: `RPC_URL_<chainId>`, `EXECUTOR_ADDRESS_<chainId>`, `LIQUIDATION_PRIVATE_KEY_<chainId>`
 4. Deploy the executor contract on the new chain via `pnpm deploy:executor`
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ For each chain, here are the parameters that need to be configured:
 
 - `options.blockInterval` (optional): Run liquidation checks every N blocks. Default: every block.
 
+- `options.watchBlocksRetryDelayMs` (optional): Delay in milliseconds before restarting the block watcher after an RPC error. Default: 5000.
+
 ### Secrets
 
 Secrets are set in the `.env` file at the root of the repository, with the following keys:

--- a/apps/client/src/index.ts
+++ b/apps/client/src/index.ts
@@ -85,14 +85,26 @@ export const launchBot = (config: ChainConfig, dataProvider: DataProvider) => {
   const blockInterval = config.blockInterval ?? 1;
   let count = 0;
 
-  watchBlocks(client, {
-    onBlock: () => {
-      if (count % blockInterval === 0) {
-        bot.run().catch((e) => {
-          console.error(`${logTag} uncaught error in bot.run():`, e);
-        });
-      }
-      count++;
-    },
-  });
+  const startWatching = () => {
+    watchBlocks(client, {
+      onBlock: () => {
+        if (count % blockInterval === 0) {
+          bot.run().catch((e) => {
+            console.error(`${logTag} uncaught error in bot.run():`, e);
+          });
+        }
+        count++;
+      },
+      onError: (error) => {
+        const retryDelay = config.watchBlocksRetryDelayMs ?? 5_000;
+        console.error(
+          `${logTag} watchBlocks error, restarting watcher in ${retryDelay}ms:`,
+          error,
+        );
+        setTimeout(startWatching, retryDelay);
+      },
+    });
+  };
+
+  startWatching();
 };

--- a/apps/client/src/script.ts
+++ b/apps/client/src/script.ts
@@ -12,6 +12,14 @@ import { startHealthServer } from "./health";
 
 import { launchBot } from ".";
 
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled rejection:", reason);
+});
+
+process.on("uncaughtException", (error) => {
+  console.error("Uncaught exception:", error);
+});
+
 async function run() {
   const configs = Object.keys(chainConfigs)
     .map((config) => {
@@ -42,18 +50,21 @@ async function run() {
 
   try {
     await startHealthServer();
-
-    for (const config of configs) {
-      const dataProvider = providersByChain.get(config.chainId);
-      if (!dataProvider) {
-        console.error(`No data provider for chain ${config.chainId}, skipping`);
-        continue;
-      }
-      launchBot(config, dataProvider);
-    }
   } catch (err) {
-    console.error(err);
-    process.exit(1);
+    console.error("Failed to start health server:", err);
+  }
+
+  for (const config of configs) {
+    const dataProvider = providersByChain.get(config.chainId);
+    if (!dataProvider) {
+      console.error(`No data provider for chain ${config.chainId}, skipping`);
+      continue;
+    }
+    try {
+      launchBot(config, dataProvider);
+    } catch (err) {
+      console.error(`Failed to launch bot for chain ${config.chainId}:`, err);
+    }
   }
 }
 

--- a/apps/config/src/types.ts
+++ b/apps/config/src/types.ts
@@ -30,6 +30,7 @@ export interface Options {
   liquidationBufferBps?: number;
   useFlashbots: boolean;
   blockInterval?: number;
+  watchBlocksRetryDelayMs?: number;
 }
 
 export type ChainConfig = Omit<Config, "options"> &

--- a/apps/data-providers/src/hyperIndex/index.ts
+++ b/apps/data-providers/src/hyperIndex/index.ts
@@ -356,9 +356,11 @@ export class HyperIndexDataProvider implements DataProvider {
           fee: BigInt(m.fee),
           rateAtTarget: BigInt(m.rateAtTarget),
           price,
-        }).accrueInterest(now);
+        });
 
-        marketsMap.set(m.id, market);
+        const lastUpdate = BigInt(m.lastUpdate);
+        const timestamp = now > lastUpdate ? now : lastUpdate;
+        marketsMap.set(m.id, market.accrueInterest(timestamp));
       }
 
       // 6. Build liquidatable positions

--- a/apps/data-providers/src/morphoApi/index.ts
+++ b/apps/data-providers/src/morphoApi/index.ts
@@ -75,7 +75,9 @@ export class MorphoApiDataProvider implements DataProvider {
             deployless: false,
           });
 
-          return [marketId, market.accrueInterest(Time.timestamp())] as const;
+          const now = BigInt(Time.timestamp());
+          const timestamp = now > market.lastUpdate ? now : market.lastUpdate;
+          return [marketId, market.accrueInterest(timestamp)] as const;
         }),
       );
 


### PR DESCRIPTION
PR description:
## Summary
- Fix watchBlocks crash by adding `onError` with configurable retry delay (`watchBlocksRetryDelayMs`, default 5s)
- Remove `process.exit(1)` and add global `uncaughtException`/`unhandledRejection` handlers so the process never dies once bots are launched
- Isolate health server startup and per-chain `launchBot` calls so a single failure doesn't prevent other bots from running
- Fix `accrueInterest` race condition where `Time.timestamp()` could be behind the block's `lastUpdate`, causing the SDK to throw