### PR TITLE
fix: map viem chain IDs to DeFiLlama slugs in pricer

### DIFF
--- a/apps/pricers/src/defillama/index.ts
+++ b/apps/pricers/src/defillama/index.ts
@@ -4,6 +4,21 @@ import type { Pricer } from "../pricer";
 
 type CoinKey = `${string}:0x${string}`;
 
+// DeFiLlama's pricing API uses its own chain slugs, which do not always match
+// viem's `chain.name`. Keep this map in sync with what DeFiLlama accepts for
+// each chain listed in apps/config/src/config.ts.
+export const DEFILLAMA_CHAIN_SLUGS: Record<number, string> = {
+  1: "ethereum",
+  130: "unichain",
+  137: "polygon",
+  143: "monad",
+  480: "wc",
+  747474: "katana",
+  999: "hyperliquid",
+  8453: "base",
+  42161: "arbitrum",
+};
+
 interface CachedPrice {
   price: number;
   fetchTimestamp: number;
@@ -72,6 +87,7 @@ export class DefiLlamaPricer implements Pricer {
   }
 
   private getCoinKey(client: Client<Transport, Chain, Account>, asset: Address): CoinKey {
-    return `${client.chain.name}:${asset}`;
+    const slug = DEFILLAMA_CHAIN_SLUGS[client.chain.id] ?? client.chain.name.toLowerCase();
+    return `${slug}:${asset}`;
   }
 }

--- a/apps/pricers/test/vitest/defillama.test.ts
+++ b/apps/pricers/test/vitest/defillama.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, beforeEach } from "vitest";
+import { describe, expect, beforeEach, it } from "vitest";
 
-import { DefiLlamaPricer } from "../../src";
+import { DEFILLAMA_CHAIN_SLUGS, DefiLlamaPricer } from "../../src";
 import { WBTC, USDC, WETH, USDC_BASE } from "../constants.js";
 import { test } from "../setup.js";
 
@@ -16,5 +16,21 @@ describe("defillama pricer", () => {
     expect(Math.floor(Math.log10(await pricer.price(client, WETH)))).toBeCloseTo(3);
     expect(Math.log10(await pricer.price(client, WBTC))).toBeGreaterThan(4);
     expect(await pricer.price(client, USDC)).toBeCloseTo(1, 3);
+  });
+
+  describe("DEFILLAMA_CHAIN_SLUGS", () => {
+    it.each([
+      [1, "ethereum"],
+      [8453, "base"],
+      [42161, "arbitrum"],
+      [130, "unichain"],
+      [137, "polygon"],
+      [747474, "katana"],
+      [999, "hyperliquid"],
+      [143, "monad"],
+      [480, "wc"],
+    ])("maps chain %i to slug %s", (chainId, slug) => {
+      expect(DEFILLAMA_CHAIN_SLUGS[chainId]).toBe(slug);
+    });
   });
 });


### PR DESCRIPTION
## Summary

The `DefiLlamaPricer` builds its price-API URL from `client.chain.name`, but DeFiLlama's chain slug doesn't always match viem's chain name. The mismatch causes `getCoinKey` to produce URLs that miss the DeFiLlama index, and the pricer silently returns `undefined` — the bot then falls through to the next pricer (or, if none, disables profit checks for the liquidation).

Affected chains in the current config:

| chain | `client.chain.name` | DeFiLlama slug | status |
|---|---|---|---|
| Arbitrum | `Arbitrum One` | `arbitrum` | broken |
| HyperEVM | `HyperEVM` | `hyperliquid` | broken |
| Monad | `Monad Mainnet` | `monad` | broken |
| World Chain | `World Chain` | `wc` | broken |
| Ethereum / Base / Unichain / Polygon / Katana | — | — | happen to match |

Fix: introduce an explicit `DEFILLAMA_CHAIN_SLUGS` map covering every chain in `apps/config/src/config.ts`, falling back to `chain.name.toLowerCase()` for chains not in the map.

## Test plan

- [x] Added unit tests asserting the slug mapping for all nine configured chains (9 new passing cases).
- [ ] Existing mainnet-fork integration test (`should test price`) still runs — unable to verify locally without a paid `RPC_URL_1`.
- [x] `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)