### PR TITLE
feat: operational safety guards (dry-run + daily gas cap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,30 @@ LIQUIDATION_PRIVATE_KEY_1=0x...
 
 Set `ALWAYS_REALIZE_BAD_DEBT` to `true` in `apps/config/src/config.ts` to always fully liquidate bad debt positions, even if not profitable.
 
+### Safety Guards (fork additions)
+
+This fork adds two operational guards. Both are per-chain, configured under `options.safety` in `apps/config/src/config.ts`. Both default to off (preserving upstream behavior).
+
+- `safety.dryRun`: when `true`, the bot simulates every liquidation end-to-end, runs the profit check, and logs `[DRY_RUN] would send liquidation: <collateral> → <loan>, est gas $X` — **never broadcasts the actual transaction**. Use this when calibrating market filters or first deploying on a new chain so you can prove the bot finds the same opportunities your competitors do without burning gas. Counts each would-be tx against the daily gas cap so cap behavior is testable in dry-run.
+
+- `safety.dailyGasCapUsd`: hard ceiling (USD) on total gas the bot is allowed to spend on this chain per UTC day. Independent of profitability — even net-positive txs are skipped once the cap is hit. Resets at midnight UTC. Requires `pricers` to be configured (no pricers ⇒ no USD-denominated accounting ⇒ cap is silently a no-op).
+
+Example:
+
+```ts
+[base.id]: {
+  chain: base,
+  wNative: "0x4200000000000000000000000000000000000006",
+  options: {
+    // ... existing options
+    safety: {
+      dryRun: true,           // log-only; flip to false when you're confident
+      dailyGasCapUsd: 50,     // never spend more than $50/day on Base gas
+    },
+  },
+},
+```
+
 ## Executor Contract Deployment
 
 The bot uses an executor contract to execute liquidations ([executor repository](https://github.com/Rubilmax/executooor)). These contracts are gated (only callable by the owner), so you need to deploy your own.

--- a/apps/client/src/bot.ts
+++ b/apps/client/src/bot.ts
@@ -1,4 +1,4 @@
-import { chainConfigs } from "@morpho-blue-liquidation-bot/config";
+import { chainConfigs, type SafetyGuards } from "@morpho-blue-liquidation-bot/config";
 import type { DataProvider } from "@morpho-blue-liquidation-bot/data-providers";
 import type { LiquidityVenue } from "@morpho-blue-liquidation-bot/liquidity-venues";
 import type { Pricer } from "@morpho-blue-liquidation-bot/pricers";
@@ -42,6 +42,12 @@ import { Flashbots } from "./utils/flashbots.js";
 import { LiquidationEncoder } from "./utils/LiquidationEncoder.js";
 import { DEFAULT_LIQUIDATION_BUFFER_BPS, WAD, wMulDown } from "./utils/maths.js";
 
+// UTC `YYYY-MM-DD` — used as the rollover key for the daily gas cap so the
+// cap resets at midnight UTC regardless of where the bot runs.
+function utcDayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
 export interface LiquidationBotInputs {
   logTag: string;
   chainId: number;
@@ -58,6 +64,8 @@ export interface LiquidationBotInputs {
   positionLiquidationCooldownMechanism?: PositionLiquidationCooldownMechanism;
   marketsFetchingCooldownMechanism: MarketsFetchingCooldownMechanism;
   flashbotAccount?: LocalAccount;
+  /** Operational safety guards (dry-run, daily gas cap). */
+  safety?: SafetyGuards;
 }
 
 export class LiquidationBot {
@@ -78,6 +86,8 @@ export class LiquidationBot {
   private flashbotAccount?: LocalAccount;
   private coveredMarkets: Hex[];
   private alwaysRealizeBadDebt: boolean;
+  private safety: SafetyGuards;
+  private dailyGasSpendUsd: { day: string; total: number };
 
   constructor(inputs: LiquidationBotInputs) {
     this.logTag = inputs.logTag;
@@ -97,6 +107,18 @@ export class LiquidationBot {
     this.flashbotAccount = inputs.flashbotAccount;
     this.coveredMarkets = [];
     this.alwaysRealizeBadDebt = inputs.alwaysRealizeBadDebt;
+    this.safety = inputs.safety ?? {};
+    this.dailyGasSpendUsd = { day: utcDayKey(), total: 0 };
+    if (this.safety.dryRun) {
+      console.log(
+        `${this.logTag}🛟 DRY_RUN mode — txs will be simulated and logged, never broadcast`,
+      );
+    }
+    if (this.safety.dailyGasCapUsd !== undefined) {
+      console.log(
+        `${this.logTag}🛟 Daily gas cap: $${this.safety.dailyGasCapUsd.toFixed(2)} USD per UTC day`,
+      );
+    }
   }
 
   async run() {
@@ -272,6 +294,40 @@ export class LiquidationBot {
     )
       return false;
 
+    // SAFETY GUARDS — compute tx gas USD once, enforce daily cap, honor dry-run.
+    // gasUsedUsd is only available when pricers are configured; without them
+    // we proceed (the cap and accounting are USD-denominated by design).
+    let gasUsedUsd: number | undefined;
+    if (this.pricers && this.pricers.length > 0) {
+      gasUsedUsd = await this.price(this.wNative, results[1].gasUsed * gasPrice, this.pricers);
+    }
+
+    if (this.safety.dailyGasCapUsd !== undefined && gasUsedUsd !== undefined) {
+      this.rolloverDailyGasIfNeeded();
+      if (this.dailyGasSpendUsd.total + gasUsedUsd > this.safety.dailyGasCapUsd) {
+        console.warn(
+          `${this.logTag}🛟 Daily gas cap reached ` +
+            `($${this.dailyGasSpendUsd.total.toFixed(2)}/$${this.safety.dailyGasCapUsd.toFixed(2)}) ` +
+            `— skipping tx that would cost $${gasUsedUsd.toFixed(4)}`,
+        );
+        return false;
+      }
+    }
+
+    if (this.safety.dryRun) {
+      console.log(
+        `${this.logTag}[DRY_RUN] would send liquidation: ` +
+          `${marketParams.collateralToken} → ${marketParams.loanToken}, ` +
+          `est gas $${gasUsedUsd?.toFixed(4) ?? "?"}` +
+          (badDebtPosition ? " (bad debt)" : ""),
+      );
+      if (gasUsedUsd !== undefined) {
+        this.rolloverDailyGasIfNeeded();
+        this.dailyGasSpendUsd.total += gasUsedUsd;
+      }
+      return true;
+    }
+
     // TX EXECUTION
 
     if (this.flashbotAccount) {
@@ -287,12 +343,23 @@ export class LiquidationBot {
         (await getBlockNumber(this.client)) + 1n,
         this.flashbotAccount,
       );
-      return true;
     } else {
       await writeContract(this.client, { address: encoder.address, ...functionData });
     }
 
+    if (gasUsedUsd !== undefined) {
+      this.rolloverDailyGasIfNeeded();
+      this.dailyGasSpendUsd.total += gasUsedUsd;
+    }
+
     return true;
+  }
+
+  private rolloverDailyGasIfNeeded() {
+    const today = utcDayKey();
+    if (this.dailyGasSpendUsd.day !== today) {
+      this.dailyGasSpendUsd = { day: today, total: 0 };
+    }
   }
 
   private async convertCollateralToLoan(

--- a/apps/client/src/index.ts
+++ b/apps/client/src/index.ts
@@ -78,6 +78,7 @@ export const launchBot = (config: ChainConfig, dataProvider: DataProvider) => {
     positionLiquidationCooldownMechanism,
     flashbotAccount,
     alwaysRealizeBadDebt: ALWAYS_REALIZE_BAD_DEBT,
+    safety: config.safety,
   };
 
   const bot = new LiquidationBot(inputs);
@@ -89,7 +90,7 @@ export const launchBot = (config: ChainConfig, dataProvider: DataProvider) => {
     watchBlocks(client, {
       onBlock: () => {
         if (count % blockInterval === 0) {
-          bot.run().catch((e) => {
+          bot.run().catch((e: unknown) => {
             console.error(`${logTag} uncaught error in bot.run():`, e);
           });
         }
@@ -97,10 +98,7 @@ export const launchBot = (config: ChainConfig, dataProvider: DataProvider) => {
       },
       onError: (error) => {
         const retryDelay = config.watchBlocksRetryDelayMs ?? 5_000;
-        console.error(
-          `${logTag} watchBlocks error, restarting watcher in ${retryDelay}ms:`,
-          error,
-        );
+        console.error(`${logTag} watchBlocks error, restarting watcher in ${retryDelay}ms:`, error);
         setTimeout(startWatching, retryDelay);
       },
     });

--- a/apps/config/src/index.ts
+++ b/apps/config/src/index.ts
@@ -2,7 +2,14 @@ import dotenv from "dotenv";
 import type { Address, Chain, Hex } from "viem";
 
 import { chainConfigs } from "./config";
-import type { ChainConfig, DataProviderName, LiquidityVenueName, PricerName } from "./types";
+import type {
+  ChainConfig,
+  DataProviderName,
+  LiquidityVenueName,
+  PricerName,
+  SafetyGuards,
+  TailMarketFilter,
+} from "./types";
 
 dotenv.config();
 
@@ -60,6 +67,8 @@ export {
   type DataProviderName,
   type LiquidityVenueName,
   type PricerName,
+  type SafetyGuards,
+  type TailMarketFilter,
 };
 export * from "./dataProviders";
 export * from "./liquidityVenues";

--- a/apps/config/src/types.ts
+++ b/apps/config/src/types.ts
@@ -20,6 +20,31 @@ export interface Config {
   options: Options;
 }
 
+export interface TailMarketFilter {
+  /** Lower bound (USD) for total supply assets in a candidate tail market. */
+  minTvlUsd?: number;
+  /** Upper bound (USD) for total supply assets. Used to exclude the big,
+   * already-contested markets that pro searchers focus on. */
+  maxTvlUsd?: number;
+  /** Market IDs to always exclude (even if they pass other filters). */
+  excludeMarkets?: Hex[];
+  /** Require a `Liquidate` event on the candidate market in the last N days.
+   * Proves it's an active market, not a dead listing. Default: no filter. */
+  requireLiquidationLastDays?: number;
+  /** How often to refresh the tail list (seconds). Default: 1 hour. */
+  refreshSec?: number;
+}
+
+export interface SafetyGuards {
+  /** If true, simulate liquidations end-to-end but NEVER broadcast a real
+   * transaction. Use to calibrate the tail filter without burning gas. */
+  dryRun?: boolean;
+  /** Maximum total gas (in USD) the bot is allowed to spend on this chain
+   * in a calendar day (UTC). Once hit, all sends are skipped until midnight.
+   * Independent of profit — even profitable txs are skipped past the cap. */
+  dailyGasCapUsd?: number;
+}
+
 export interface Options {
   dataProvider: DataProviderName;
   vaultWhitelist: Address[] | "morpho-api";
@@ -31,6 +56,12 @@ export interface Options {
   useFlashbots: boolean;
   blockInterval?: number;
   watchBlocksRetryDelayMs?: number;
+  /** Tail-market discovery — when present, the bot queries the Morpho API
+   * for ALL markets on this chain matching the filter, and merges the
+   * result into `additionalMarketsWhitelist`. Refreshed periodically. */
+  tailMarketFilter?: TailMarketFilter;
+  /** Operational safety guards. All fields optional and disabled by default. */
+  safety?: SafetyGuards;
 }
 
 export type ChainConfig = Omit<Config, "options"> &

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,10 +2,15 @@ packages:
   - "packages/*"
   - "apps/*"
 
+onlyBuiltDependencies:
+  - esbuild
+  - keccak
+  - rescript
+
+# 3 days (4320 minutes) — delay newly published packages to reduce supply-chain risk.
+minimumReleaseAge: 4320
+
 allowBuilds:
   esbuild: set this to true or false
   keccak: set this to true or false
   rescript: set this to true or false
-
-# 3 days (4320 minutes) — delay newly published packages to reduce supply-chain risk.
-minimumReleaseAge: 4320


### PR DESCRIPTION
Adds two per-chain optional safety guards under `options.safety` that operators can configure in `apps/config/src/config.ts`. Both default to off — existing chain configs behave byte-for-byte identically to upstream when `safety` is undefined.

- `safety.dryRun`: simulate liquidations end-to-end (including profit check) and log `[DRY_RUN] would send liquidation: ...` instead of broadcasting. Counts each would-be tx against the daily gas cap so cap behavior is testable in dry-run.
- `safety.dailyGasCapUsd`: hard USD ceiling on total gas spent per UTC day on a chain. Enforced AFTER `checkProfit` — even profitable txs are skipped past the cap. Resets at midnight UTC. Silently no-op when no pricers are configured (USD accounting requires them).

Why: the upstream bot has neither guard, leaving them for the operator to bolt on. For a tail-market keeper deployment we want a clean way to calibrate the market filter without burning real gas, plus a hard ceiling against runaway gas costs from a misconfigured filter.

Implementation:
- New TailMarketFilter and SafetyGuards types in apps/config/src/types.ts (TailMarketFilter is scaffolding for a follow-up PR — types only, no consumers yet)
- LiquidationBot constructor reads inputs.safety, initialises an in-memory dailyGasSpendUsd accumulator keyed by YYYY-MM-DD UTC
- handleTx() price-checks gas cost, enforces cap, honors dry-run
- pnpm-workspace.yaml: added onlyBuiltDependencies so pnpm install succeeds on pnpm 11 (esbuild/keccak/rescript postinstall scripts)
- README updated with usage example