### PR TITLE
fix: align HyperIndex Morpho accounting

### DIFF
--- a/apps/hyperindex/src/handlers/MorphoBlue.ts
+++ b/apps/hyperindex/src/handlers/MorphoBlue.ts
@@ -2,6 +2,8 @@ import { Morpho } from "generated";
 import { getAddress } from "viem";
 import { marketId, positionId, authorizationId } from "../utils/ids.js";
 
+const zeroFloorSub = (a: bigint, b: bigint) => (a > b ? a - b : 0n);
+
 Morpho.CreateMarket.handler(async ({ event, context }) => {
   const id = marketId(event.chainId, event.params.id);
 
@@ -172,7 +174,7 @@ Morpho.Repay.handler(async ({ event, context }) => {
   if (market) {
     context.Market.set({
       ...market,
-      totalBorrowAssets: market.totalBorrowAssets - event.params.assets,
+      totalBorrowAssets: zeroFloorSub(market.totalBorrowAssets, event.params.assets),
       totalBorrowShares: market.totalBorrowShares - event.params.shares,
     });
   }
@@ -197,12 +199,15 @@ Morpho.Liquidate.handler(async ({ event, context }) => {
   const mId = marketId(event.chainId, event.params.id);
   const market = await context.Market.get(mId);
   if (market) {
+    const totalBorrowAssetsAfterRepay = zeroFloorSub(
+      market.totalBorrowAssets,
+      event.params.repaidAssets,
+    );
+
     context.Market.set({
       ...market,
       totalSupplyAssets: market.totalSupplyAssets - event.params.badDebtAssets,
-      totalSupplyShares: market.totalSupplyShares - event.params.badDebtShares,
-      totalBorrowAssets:
-        market.totalBorrowAssets - event.params.repaidAssets - event.params.badDebtAssets,
+      totalBorrowAssets: zeroFloorSub(totalBorrowAssetsAfterRepay, event.params.badDebtAssets),
       totalBorrowShares:
         market.totalBorrowShares - event.params.repaidShares - event.params.badDebtShares,
     });


### PR DESCRIPTION
## Summary

Fix the HyperIndex Morpho market accounting handlers so indexed market totals match Morpho Blue contract state.

- Zero-floor `totalBorrowAssets` when handling `Repay`, matching Morpho Blue's `UtilsLib.zeroFloorSub` behavior when emitted `assets` can round one wei above remaining borrow assets.
- Zero-floor the liquidation `repaidAssets` borrow-asset decrement before applying bad debt.
- Stop subtracting `badDebtShares` from `totalSupplyShares`; bad debt shares are borrow shares, while bad debt reduces supply assets through the lower assets-per-share ratio.

## Root cause

The handlers applied event deltas directly. Morpho Blue deliberately zero-floors repay/liquidation borrow-asset decrements, and liquidation bad debt reduces `totalBorrowAssets`, `totalSupplyAssets`, and `totalBorrowShares`, not `totalSupplyShares`.

## Validation

- `pnpm build:config`
- `ENVIO_API_TOKEN=dummy pnpm --filter @morpho-blue-liquidation-bot/hyperindex generate:config`
- `pnpm --filter @morpho-blue-liquidation-bot/hyperindex codegen`
- `pnpm exec prettier --check apps/hyperindex/src/handlers/MorphoBlue.ts`

Also attempted `pnpm --filter @morpho-blue-liquidation-bot/hyperindex exec tsc --noEmit -p tsconfig.json`; it fails in generated Envio files because declarations for generated `*.res.mjs` modules are missing, unrelated to this handler patch.
