### PR TITLE
feat: per-chain partial liquidation

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event.pull_request.draft == false
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run Claude Code Review
         if: steps.changed-files.outputs.files != ''
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@51705da45eecce209d4700538bf8377d5b5fc695 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           version: stable
       - name: Run liquidity venue tests
@@ -35,18 +35,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           version: stable
       - name: Run pricers tests
@@ -58,18 +58,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           version: stable
       - name: Run liquidation execution tests
@@ -82,18 +82,18 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
       - name: Install dependencies
         run: pnpm i --frozen-lockfile
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
           version: stable
       - name: Build config package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
-          version: stable
+          version: "1.5.1"
       - name: Run liquidity venue tests
         run: pnpm test:liquidity-venues
         env:
@@ -48,7 +48,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
-          version: stable
+          version: "1.5.1"
       - name: Run pricers tests
         run: pnpm test:pricers
         env:
@@ -71,7 +71,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
-          version: stable
+          version: "1.5.1"
       - name: Run liquidation execution tests
         run: pnpm test:client
         env:
@@ -95,7 +95,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d # v1
         with:
-          version: stable
+          version: "1.5.1"
       - name: Build config package
         run: pnpm build:config
       - name: Run hyperindex tests

--- a/README.md
+++ b/README.md
@@ -101,6 +101,30 @@ LIQUIDATION_PRIVATE_KEY_1=0x...
 
 Set `ALWAYS_REALIZE_BAD_DEBT` to `true` in `apps/config/src/config.ts` to always fully liquidate bad debt positions, even if not profitable.
 
+### Partial Liquidation
+
+By default, every liquidatable position is attempted as a single full-seize call (the legacy path). For large positions where the full seize would push too much through the configured liquidity venues, the bot can optionally fall back to a smaller seize.
+
+Configure it in `apps/config/src/partialLiquidation.ts`:
+
+```ts
+export const partialLiquidationMinRepay: Record<number, Partial<Record<Address, bigint>>> = {
+  [mainnet.id]: {
+    // 100 USDC. Threshold is in loan-asset atoms.
+    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": 100_000_000n,
+  },
+};
+```
+
+The threshold is a position-level mode switch:
+
+- **Chain absent from the map** → partial liquidation disabled for that chain.
+- **Chain present, loan asset absent from the chain's submap** → that market falls back to a single full-seize attempt.
+- **Chain present, loan asset present, `position.borrowAssets < threshold`** → single full-seize attempt (regardless of bad-debt status — small positions are never partialised).
+- **Chain present, loan asset present, `position.borrowAssets >= threshold`** → partial mode: the bot simulates 10 candidate seize amounts (`seizableCollateral / 2^i` for `i ∈ [0, 10)`) and submits the candidate with the **largest seize amount** among the profitable simulations.
+
+Thresholds are in the loan asset's smallest unit. For USDC (6 decimals) `100_000_000n` = 100 USDC; for DAI (18 decimals) `100_000_000_000_000_000_000n` = 100 DAI.
+
 ## Executor Contract Deployment
 
 The bot uses an executor contract to execute liquidations ([executor repository](https://github.com/Rubilmax/executooor)). These contracts are gated (only callable by the owner), so you need to deploy your own.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ By default, every liquidatable position is attempted as a single full-seize call
 Configure it in `apps/config/src/partialLiquidation.ts`:
 
 ```ts
-export const partialLiquidationMinRepay: Record<number, Partial<Record<Address, bigint>>> = {
+export const partialLiquidationMinBorrow: Record<number, Partial<Record<Address, bigint>>> = {
   [mainnet.id]: {
     // 100 USDC. Threshold is in loan-asset atoms.
     "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": 100_000_000n,

--- a/apps/client/src/bot.ts
+++ b/apps/client/src/bot.ts
@@ -58,6 +58,14 @@ export interface LiquidationBotInputs {
   positionLiquidationCooldownMechanism?: PositionLiquidationCooldownMechanism;
   marketsFetchingCooldownMechanism: MarketsFetchingCooldownMechanism;
   flashbotAccount?: LocalAccount;
+  /**
+   * When set, enables partial liquidation: the bot tries candidate seize amounts
+   * `seizableCollateral / 2^i` for i in [0, 10) from largest to smallest, skipping
+   * any candidate whose collateral USD value is below this threshold (except a
+   * full bad-debt seize, which is always tried). Submits the first profitable
+   * candidate. Undefined disables the feature (single-attempt legacy behavior).
+   */
+  partialLiquidationMinSeizeUsd?: number;
 }
 
 export class LiquidationBot {
@@ -78,6 +86,7 @@ export class LiquidationBot {
   private flashbotAccount?: LocalAccount;
   private coveredMarkets: Hex[];
   private alwaysRealizeBadDebt: boolean;
+  private partialLiquidationMinSeizeUsd?: number;
 
   constructor(inputs: LiquidationBotInputs) {
     this.logTag = inputs.logTag;
@@ -97,6 +106,7 @@ export class LiquidationBot {
     this.flashbotAccount = inputs.flashbotAccount;
     this.coveredMarkets = [];
     this.alwaysRealizeBadDebt = inputs.alwaysRealizeBadDebt;
+    this.partialLiquidationMinSeizeUsd = inputs.partialLiquidationMinSeizeUsd;
   }
 
   async run() {
@@ -113,13 +123,39 @@ export class LiquidationBot {
 
   private async liquidate(position: AccrualPosition) {
     const marketParams = position.market.params;
-    const seizableCollateral = position.seizableCollateral ?? 0n;
-    const badDebtPosition = seizableCollateral === position.collateral;
+    const fullSeizableCollateral = position.seizableCollateral ?? 0n;
 
     if (!this.checkCooldown(MarketUtils.getMarketId(marketParams), position.user)) return;
 
-    const { client, executorAddress } = this;
+    const candidates =
+      this.partialLiquidationMinSeizeUsd === undefined
+        ? [fullSeizableCollateral]
+        : await this.partialLiquidationCandidates(
+            marketParams.collateralToken,
+            fullSeizableCollateral,
+            position.collateral,
+            this.partialLiquidationMinSeizeUsd,
+          );
 
+    for (const seizableCollateral of candidates) {
+      const badDebtPosition = seizableCollateral === position.collateral;
+      const submitted = await this.attemptLiquidation(
+        position.user,
+        marketParams,
+        seizableCollateral,
+        badDebtPosition,
+      );
+      if (submitted) return;
+    }
+  }
+
+  private async attemptLiquidation(
+    user: Address,
+    marketParams: IMarketParams,
+    seizableCollateral: bigint,
+    badDebtPosition: boolean,
+  ): Promise<boolean> {
+    const { client, executorAddress } = this;
     const encoder = new LiquidationEncoder(executorAddress, client);
 
     if (
@@ -129,7 +165,7 @@ export class LiquidationBot {
         encoder,
       ))
     )
-      return;
+      return false;
 
     encoder.erc20Approve(marketParams.loanToken, this.chainAddresses.morpho, maxUint256);
 
@@ -142,7 +178,7 @@ export class LiquidationBot {
         irm: marketParams.irm,
         lltv: BigInt(marketParams.lltv),
       },
-      position.user,
+      user,
       seizableCollateral,
       0n,
       encoder.flush(),
@@ -156,34 +192,59 @@ export class LiquidationBot {
 
       if (success)
         console.log(
-          `${this.logTag}Liquidated ${position.user} on ${MarketUtils.getMarketId(marketParams)}`,
+          `${this.logTag}Liquidated ${user} on ${MarketUtils.getMarketId(marketParams)} (seized ${seizableCollateral})`,
         );
       else
         console.log(
-          `${this.logTag}ℹ️ Skipped ${position.user} on ${MarketUtils.getMarketId(marketParams)} (not profitable)`,
+          `${this.logTag}ℹ️ Skipped ${user} on ${MarketUtils.getMarketId(marketParams)} (not profitable, seize ${seizableCollateral})`,
         );
+
+      return Boolean(success);
     } catch (error) {
       console.error(
-        `${this.logTag}Failed to liquidate ${position.user} on ${MarketUtils.getMarketId(marketParams)}`,
+        `${this.logTag}Failed to liquidate ${user} on ${MarketUtils.getMarketId(marketParams)} (seize ${seizableCollateral})`,
         error,
       );
+      return false;
     }
   }
 
   private async preLiquidate(position: PreLiquidationPosition) {
     const marketParams = position.market.params;
-    const seizableCollateral = this.decreaseSeizableCollateral(
-      position.seizableCollateral ?? 0n,
-      false,
-    );
+    const fullSeizableCollateral = position.seizableCollateral ?? 0n;
 
     if (!this.checkCooldown(MarketUtils.getMarketId(marketParams), position.user)) return;
 
-    const { client, executorAddress } = this;
+    const candidates =
+      this.partialLiquidationMinSeizeUsd === undefined
+        ? [fullSeizableCollateral]
+        : await this.partialLiquidationCandidates(
+            marketParams.collateralToken,
+            fullSeizableCollateral,
+            position.collateral,
+            this.partialLiquidationMinSeizeUsd,
+          );
 
+    for (const seizableCollateral of candidates) {
+      const submitted = await this.attemptPreLiquidation(
+        position,
+        marketParams,
+        this.decreaseSeizableCollateral(seizableCollateral, false),
+      );
+      if (submitted) return;
+    }
+  }
+
+  private async attemptPreLiquidation(
+    position: PreLiquidationPosition,
+    marketParams: IMarketParams,
+    seizableCollateral: bigint,
+  ): Promise<boolean> {
+    const { client, executorAddress } = this;
     const encoder = new LiquidationEncoder(executorAddress, client);
 
-    if (!(await this.convertCollateralToLoan(marketParams, seizableCollateral, encoder))) return;
+    if (!(await this.convertCollateralToLoan(marketParams, seizableCollateral, encoder)))
+      return false;
 
     encoder.erc20Approve(marketParams.loanToken, position.preLiquidation, maxUint256);
 
@@ -203,18 +264,52 @@ export class LiquidationBot {
 
       if (success)
         console.log(
-          `${this.logTag}Pre-liquidated ${position.user} on ${MarketUtils.getMarketId(marketParams)}`,
+          `${this.logTag}Pre-liquidated ${position.user} on ${MarketUtils.getMarketId(marketParams)} (seized ${seizableCollateral})`,
         );
       else
         console.log(
-          `${this.logTag}ℹ️ Skipped ${position.user} on ${MarketUtils.getMarketId(marketParams)} (not profitable)`,
+          `${this.logTag}ℹ️ Skipped ${position.user} on ${MarketUtils.getMarketId(marketParams)} (not profitable, seize ${seizableCollateral})`,
         );
+
+      return Boolean(success);
     } catch (error) {
       console.error(
-        `${this.logTag}Failed to pre-liquidate ${position.user} on ${MarketUtils.getMarketId(marketParams)}`,
+        `${this.logTag}Failed to pre-liquidate ${position.user} on ${MarketUtils.getMarketId(marketParams)} (seize ${seizableCollateral})`,
         error,
       );
+      return false;
     }
+  }
+
+  /**
+   * Builds the list of seize-amount candidates to try, from largest to smallest:
+   * `seizableCollateral / 2^i` for i in [0, 10). Filters out duplicates and zero,
+   * and drops candidates whose collateral USD value is below `minSeizeUsd` unless
+   * the candidate equals `positionCollateral` (i.e., full bad-debt realization).
+   * If no pricers are configured, the USD filter is skipped (all candidates kept).
+   */
+  private async partialLiquidationCandidates(
+    collateralToken: Address,
+    seizableCollateral: bigint,
+    positionCollateral: bigint,
+    minSeizeUsd: number,
+  ): Promise<bigint[]> {
+    const raw = Array.from({ length: 10 }, (_, i) => seizableCollateral / (1n << BigInt(i))).filter(
+      (amount, index, arr) => amount > 0n && arr.indexOf(amount) === index,
+    );
+
+    if (this.pricers === undefined || this.pricers.length === 0) return raw;
+
+    const kept: bigint[] = [];
+    for (const candidate of raw) {
+      if (candidate === positionCollateral) {
+        kept.push(candidate);
+        continue;
+      }
+      const usdValue = await this.price(collateralToken, candidate, this.pricers);
+      if (usdValue !== undefined && usdValue >= minSeizeUsd) kept.push(candidate);
+    }
+    return kept;
   }
 
   private async handleTx(

--- a/apps/client/src/bot.ts
+++ b/apps/client/src/bot.ts
@@ -58,21 +58,8 @@ export interface LiquidationBotInputs {
   positionLiquidationCooldownMechanism?: PositionLiquidationCooldownMechanism;
   marketsFetchingCooldownMechanism: MarketsFetchingCooldownMechanism;
   flashbotAccount?: LocalAccount;
-  /**
-   * Per-loan-asset minimum borrow-assets threshold (in loan-asset atoms). The
-   * threshold acts as a position-level mode switch:
-   *
-   * - Loan asset missing from this submap → single full-seize attempt (legacy).
-   * - Loan asset present, `position.borrowAssets < threshold` → single full-seize
-   *   attempt (regardless of bad-debt status).
-   * - Loan asset present, `position.borrowAssets >= threshold` → partial mode:
-   *   the bot simulates candidate seize amounts `seizableCollateral / 2^i` for
-   *   i in [0, 10) and submits the candidate with the largest seize amount
-   *   among the profitable simulations.
-   *
-   * This is the per-chain submap from `partialLiquidationMinRepay` in the
-   * config package — the launcher slices it by `config.chainId`.
-   */
+  // Per-chain submap from config's `partialLiquidationMinRepay`. See the
+  // "Partial Liquidation" section of the README for the semantics.
   partialLiquidationMinRepay?: Partial<Record<Address, bigint>>;
 }
 
@@ -374,34 +361,19 @@ export class LiquidationBot {
     return { encoder, calls, profitable };
   }
 
-  /**
-   * Returns true iff this loan asset is configured for partial liquidation on this
-   * chain AND the position's outstanding borrow assets are at or above the threshold.
-   * The threshold acts as a position-level mode switch: smaller positions are always
-   * liquidated in a single full attempt (regardless of bad-debt status); larger ones
-   * go through the candidate-and-pick-biggest path.
-   */
   private partialLiquidationEnabledFor(loanToken: Address, positionBorrowAssets: bigint): boolean {
     const minRepay = this.partialLiquidationMinRepay?.[getAddress(loanToken)];
     if (minRepay === undefined) return false;
     return positionBorrowAssets >= minRepay;
   }
 
-  /**
-   * Builds the list of seize-amount candidates to try, from largest to smallest:
-   * `seizableCollateral / 2^i` for i in [0, 10). Deduped, zero-stripped.
-   */
   private partialLiquidationCandidates(seizableCollateral: bigint): bigint[] {
     return Array.from({ length: 10 }, (_, i) => seizableCollateral / (1n << BigInt(i))).filter(
       (amount, index, arr) => amount > 0n && arr.indexOf(amount) === index,
     );
   }
 
-  /**
-   * Simulates the full executor call, then runs the profitability check.
-   * Returns `true` if profitable (or unconditionally on bad-debt + `alwaysRealizeBadDebt`),
-   * `false` if simulation succeeded but not profitable, `undefined` if simulation reverted.
-   */
+  // Returns true if profitable, false if not profitable, undefined if simulation reverted.
   private async simulateAndCheckProfit(
     encoder: LiquidationEncoder,
     calls: Hex[],

--- a/apps/client/src/bot.ts
+++ b/apps/client/src/bot.ts
@@ -58,9 +58,9 @@ export interface LiquidationBotInputs {
   positionLiquidationCooldownMechanism?: PositionLiquidationCooldownMechanism;
   marketsFetchingCooldownMechanism: MarketsFetchingCooldownMechanism;
   flashbotAccount?: LocalAccount;
-  // Per-chain submap from config's `partialLiquidationMinRepay`. See the
+  // Per-chain submap from config's `partialLiquidationMinBorrow`. See the
   // "Partial Liquidation" section of the README for the semantics.
-  partialLiquidationMinRepay?: Partial<Record<Address, bigint>>;
+  partialLiquidationMinBorrow?: Partial<Record<Address, bigint>>;
 }
 
 interface PreparedLiquidation {
@@ -87,7 +87,7 @@ export class LiquidationBot {
   private flashbotAccount?: LocalAccount;
   private coveredMarkets: Hex[];
   private alwaysRealizeBadDebt: boolean;
-  private partialLiquidationMinRepay?: Partial<Record<Address, bigint>>;
+  private partialLiquidationMinBorrow?: Partial<Record<Address, bigint>>;
 
   constructor(inputs: LiquidationBotInputs) {
     this.logTag = inputs.logTag;
@@ -107,7 +107,7 @@ export class LiquidationBot {
     this.flashbotAccount = inputs.flashbotAccount;
     this.coveredMarkets = [];
     this.alwaysRealizeBadDebt = inputs.alwaysRealizeBadDebt;
-    this.partialLiquidationMinRepay = inputs.partialLiquidationMinRepay;
+    this.partialLiquidationMinBorrow = inputs.partialLiquidationMinBorrow;
   }
 
   async run() {
@@ -362,9 +362,9 @@ export class LiquidationBot {
   }
 
   private partialLiquidationEnabledFor(loanToken: Address, positionBorrowAssets: bigint): boolean {
-    const minRepay = this.partialLiquidationMinRepay?.[getAddress(loanToken)];
-    if (minRepay === undefined) return false;
-    return positionBorrowAssets >= minRepay;
+    const minBorrow = this.partialLiquidationMinBorrow?.[getAddress(loanToken)];
+    if (minBorrow === undefined) return false;
+    return positionBorrowAssets >= minBorrow;
   }
 
   private partialLiquidationCandidates(seizableCollateral: bigint): bigint[] {

--- a/apps/client/src/bot.ts
+++ b/apps/client/src/bot.ts
@@ -7,6 +7,7 @@ import {
   ChainAddresses,
   getChainAddresses,
   type IMarketParams,
+  type Market,
   MarketUtils,
   PreLiquidationPosition,
 } from "@morpho-org/blue-sdk";
@@ -59,13 +60,25 @@ export interface LiquidationBotInputs {
   marketsFetchingCooldownMechanism: MarketsFetchingCooldownMechanism;
   flashbotAccount?: LocalAccount;
   /**
-   * When set, enables partial liquidation: the bot tries candidate seize amounts
-   * `seizableCollateral / 2^i` for i in [0, 10) from largest to smallest, skipping
-   * any candidate whose collateral USD value is below this threshold (except a
-   * full bad-debt seize, which is always tried). Submits the first profitable
-   * candidate. Undefined disables the feature (single-attempt legacy behavior).
+   * Per-loan-asset minimum repaid amount (in loan-asset atoms) for a partial-
+   * liquidation candidate to be considered. When undefined, or when the loan
+   * asset of a given market is not in this submap, the bot falls back to a
+   * single full-seize attempt. When defined and the loan asset is listed, the
+   * bot tries candidate seize amounts `seizableCollateral / 2^i` for i in [0, 10),
+   * keeps those whose repaid loan-asset amount is ≥ this threshold (plus a full
+   * bad-debt seize regardless of threshold), simulates each, and submits the
+   * one with the largest seize amount among the profitable simulations.
+   *
+   * This is the per-chain submap from `partialLiquidationMinRepay` in the
+   * config package — the launcher slices it by `config.chainId`.
    */
-  partialLiquidationMinSeizeUsd?: number;
+  partialLiquidationMinRepay?: Partial<Record<Address, bigint>>;
+}
+
+interface PreparedLiquidation {
+  encoder: LiquidationEncoder;
+  calls: Hex[];
+  profitable: boolean;
 }
 
 export class LiquidationBot {
@@ -86,7 +99,7 @@ export class LiquidationBot {
   private flashbotAccount?: LocalAccount;
   private coveredMarkets: Hex[];
   private alwaysRealizeBadDebt: boolean;
-  private partialLiquidationMinSeizeUsd?: number;
+  private partialLiquidationMinRepay?: Partial<Record<Address, bigint>>;
 
   constructor(inputs: LiquidationBotInputs) {
     this.logTag = inputs.logTag;
@@ -106,7 +119,7 @@ export class LiquidationBot {
     this.flashbotAccount = inputs.flashbotAccount;
     this.coveredMarkets = [];
     this.alwaysRealizeBadDebt = inputs.alwaysRealizeBadDebt;
-    this.partialLiquidationMinSeizeUsd = inputs.partialLiquidationMinSeizeUsd;
+    this.partialLiquidationMinRepay = inputs.partialLiquidationMinRepay;
   }
 
   async run() {
@@ -127,34 +140,100 @@ export class LiquidationBot {
 
     if (!this.checkCooldown(MarketUtils.getMarketId(marketParams), position.user)) return;
 
-    const candidates =
-      this.partialLiquidationMinSeizeUsd === undefined
-        ? [fullSeizableCollateral]
-        : await this.partialLiquidationCandidates(
-            marketParams.collateralToken,
-            fullSeizableCollateral,
-            position.collateral,
-            this.partialLiquidationMinSeizeUsd,
-          );
+    const minRepay = this.partialLiquidationMinRepay?.[getAddress(marketParams.loanToken)];
 
+    if (minRepay === undefined) {
+      // Loan asset not configured for partial liquidation → single full-seize attempt.
+      await this.runSingleLiquidationAttempt(
+        position.user,
+        marketParams,
+        fullSeizableCollateral,
+        fullSeizableCollateral === position.collateral,
+      );
+      return;
+    }
+
+    // Partial liquidation enabled: simulate every candidate, keep the profitable ones,
+    // submit the candidate with the largest seize amount.
+    const candidates = this.partialLiquidationCandidates(
+      fullSeizableCollateral,
+      position.collateral,
+      position.market,
+      minRepay,
+    );
+
+    const successes: { seizableCollateral: bigint; prepared: PreparedLiquidation }[] = [];
     for (const seizableCollateral of candidates) {
       const badDebtPosition = seizableCollateral === position.collateral;
-      const submitted = await this.attemptLiquidation(
+      const prepared = await this.prepareLiquidation(
         position.user,
         marketParams,
         seizableCollateral,
         badDebtPosition,
       );
-      if (submitted) return;
+      if (prepared?.profitable) successes.push({ seizableCollateral, prepared });
+    }
+
+    if (successes.length === 0) return;
+
+    const winner = successes.reduce((a, b) =>
+      a.seizableCollateral > b.seizableCollateral ? a : b,
+    );
+
+    try {
+      await this.sendLiquidationTx(winner.prepared);
+      console.log(
+        `${this.logTag}Liquidated ${position.user} on ${MarketUtils.getMarketId(marketParams)} (seized ${winner.seizableCollateral}, biggest of ${successes.length} profitable candidate(s))`,
+      );
+    } catch (error) {
+      console.error(
+        `${this.logTag}Failed to liquidate ${position.user} on ${MarketUtils.getMarketId(marketParams)} (seize ${winner.seizableCollateral})`,
+        error,
+      );
     }
   }
 
-  private async attemptLiquidation(
+  private async runSingleLiquidationAttempt(
     user: Address,
     marketParams: IMarketParams,
     seizableCollateral: bigint,
     badDebtPosition: boolean,
-  ): Promise<boolean> {
+  ) {
+    const prepared = await this.prepareLiquidation(
+      user,
+      marketParams,
+      seizableCollateral,
+      badDebtPosition,
+    );
+
+    if (prepared === null) return;
+
+    if (!prepared.profitable) {
+      console.log(
+        `${this.logTag}ℹ️ Skipped ${user} on ${MarketUtils.getMarketId(marketParams)} (not profitable, seize ${seizableCollateral})`,
+      );
+      return;
+    }
+
+    try {
+      await this.sendLiquidationTx(prepared);
+      console.log(
+        `${this.logTag}Liquidated ${user} on ${MarketUtils.getMarketId(marketParams)} (seized ${seizableCollateral})`,
+      );
+    } catch (error) {
+      console.error(
+        `${this.logTag}Failed to liquidate ${user} on ${MarketUtils.getMarketId(marketParams)} (seize ${seizableCollateral})`,
+        error,
+      );
+    }
+  }
+
+  private async prepareLiquidation(
+    user: Address,
+    marketParams: IMarketParams,
+    seizableCollateral: bigint,
+    badDebtPosition: boolean,
+  ): Promise<PreparedLiquidation | null> {
     const { client, executorAddress } = this;
     const encoder = new LiquidationEncoder(executorAddress, client);
 
@@ -165,7 +244,7 @@ export class LiquidationBot {
         encoder,
       ))
     )
-      return false;
+      return null;
 
     encoder.erc20Approve(marketParams.loanToken, this.chainAddresses.morpho, maxUint256);
 
@@ -187,26 +266,15 @@ export class LiquidationBot {
 
     const calls = encoder.flush();
 
-    try {
-      const success = await this.handleTx(encoder, calls, marketParams, badDebtPosition);
+    const profitable = await this.simulateAndCheckProfit(
+      encoder,
+      calls,
+      marketParams,
+      badDebtPosition,
+    );
+    if (profitable === undefined) return null;
 
-      if (success)
-        console.log(
-          `${this.logTag}Liquidated ${user} on ${MarketUtils.getMarketId(marketParams)} (seized ${seizableCollateral})`,
-        );
-      else
-        console.log(
-          `${this.logTag}ℹ️ Skipped ${user} on ${MarketUtils.getMarketId(marketParams)} (not profitable, seize ${seizableCollateral})`,
-        );
-
-      return Boolean(success);
-    } catch (error) {
-      console.error(
-        `${this.logTag}Failed to liquidate ${user} on ${MarketUtils.getMarketId(marketParams)} (seize ${seizableCollateral})`,
-        error,
-      );
-      return false;
-    }
+    return { encoder, calls, profitable };
   }
 
   private async preLiquidate(position: PreLiquidationPosition) {
@@ -215,36 +283,89 @@ export class LiquidationBot {
 
     if (!this.checkCooldown(MarketUtils.getMarketId(marketParams), position.user)) return;
 
-    const candidates =
-      this.partialLiquidationMinSeizeUsd === undefined
-        ? [fullSeizableCollateral]
-        : await this.partialLiquidationCandidates(
-            marketParams.collateralToken,
-            fullSeizableCollateral,
-            position.collateral,
-            this.partialLiquidationMinSeizeUsd,
-          );
+    const minRepay = this.partialLiquidationMinRepay?.[getAddress(marketParams.loanToken)];
 
-    for (const seizableCollateral of candidates) {
-      const submitted = await this.attemptPreLiquidation(
+    if (minRepay === undefined) {
+      await this.runSinglePreLiquidationAttempt(
         position,
         marketParams,
-        this.decreaseSeizableCollateral(seizableCollateral, false),
+        this.decreaseSeizableCollateral(fullSeizableCollateral, false),
       );
-      if (submitted) return;
+      return;
+    }
+
+    const candidates = this.partialLiquidationCandidates(
+      fullSeizableCollateral,
+      position.collateral,
+      position.market,
+      minRepay,
+    );
+
+    const successes: { seizableCollateral: bigint; prepared: PreparedLiquidation }[] = [];
+    for (const seizableCollateral of candidates) {
+      const adjusted = this.decreaseSeizableCollateral(seizableCollateral, false);
+      const prepared = await this.preparePreLiquidation(position, marketParams, adjusted);
+      if (prepared?.profitable) successes.push({ seizableCollateral: adjusted, prepared });
+    }
+
+    if (successes.length === 0) return;
+
+    const winner = successes.reduce((a, b) =>
+      a.seizableCollateral > b.seizableCollateral ? a : b,
+    );
+
+    try {
+      await this.sendLiquidationTx(winner.prepared);
+      console.log(
+        `${this.logTag}Pre-liquidated ${position.user} on ${MarketUtils.getMarketId(marketParams)} (seized ${winner.seizableCollateral}, biggest of ${successes.length} profitable candidate(s))`,
+      );
+    } catch (error) {
+      console.error(
+        `${this.logTag}Failed to pre-liquidate ${position.user} on ${MarketUtils.getMarketId(marketParams)} (seize ${winner.seizableCollateral})`,
+        error,
+      );
     }
   }
 
-  private async attemptPreLiquidation(
+  private async runSinglePreLiquidationAttempt(
     position: PreLiquidationPosition,
     marketParams: IMarketParams,
     seizableCollateral: bigint,
-  ): Promise<boolean> {
+  ) {
+    const prepared = await this.preparePreLiquidation(position, marketParams, seizableCollateral);
+
+    if (prepared === null) return;
+
+    if (!prepared.profitable) {
+      console.log(
+        `${this.logTag}ℹ️ Skipped ${position.user} on ${MarketUtils.getMarketId(marketParams)} (not profitable, seize ${seizableCollateral})`,
+      );
+      return;
+    }
+
+    try {
+      await this.sendLiquidationTx(prepared);
+      console.log(
+        `${this.logTag}Pre-liquidated ${position.user} on ${MarketUtils.getMarketId(marketParams)} (seized ${seizableCollateral})`,
+      );
+    } catch (error) {
+      console.error(
+        `${this.logTag}Failed to pre-liquidate ${position.user} on ${MarketUtils.getMarketId(marketParams)} (seize ${seizableCollateral})`,
+        error,
+      );
+    }
+  }
+
+  private async preparePreLiquidation(
+    position: PreLiquidationPosition,
+    marketParams: IMarketParams,
+    seizableCollateral: bigint,
+  ): Promise<PreparedLiquidation | null> {
     const { client, executorAddress } = this;
     const encoder = new LiquidationEncoder(executorAddress, client);
 
     if (!(await this.convertCollateralToLoan(marketParams, seizableCollateral, encoder)))
-      return false;
+      return null;
 
     encoder.erc20Approve(marketParams.loanToken, position.preLiquidation, maxUint256);
 
@@ -259,65 +380,49 @@ export class LiquidationBot {
 
     const calls = encoder.flush();
 
-    try {
-      const success = await this.handleTx(encoder, calls, marketParams, false);
+    const profitable = await this.simulateAndCheckProfit(encoder, calls, marketParams, false);
+    if (profitable === undefined) return null;
 
-      if (success)
-        console.log(
-          `${this.logTag}Pre-liquidated ${position.user} on ${MarketUtils.getMarketId(marketParams)} (seized ${seizableCollateral})`,
-        );
-      else
-        console.log(
-          `${this.logTag}ℹ️ Skipped ${position.user} on ${MarketUtils.getMarketId(marketParams)} (not profitable, seize ${seizableCollateral})`,
-        );
-
-      return Boolean(success);
-    } catch (error) {
-      console.error(
-        `${this.logTag}Failed to pre-liquidate ${position.user} on ${MarketUtils.getMarketId(marketParams)} (seize ${seizableCollateral})`,
-        error,
-      );
-      return false;
-    }
+    return { encoder, calls, profitable };
   }
 
   /**
    * Builds the list of seize-amount candidates to try, from largest to smallest:
    * `seizableCollateral / 2^i` for i in [0, 10). Filters out duplicates and zero,
-   * and drops candidates whose collateral USD value is below `minSeizeUsd` unless
-   * the candidate equals `positionCollateral` (i.e., full bad-debt realization).
-   * If no pricers are configured, the USD filter is skipped (all candidates kept).
+   * and drops candidates whose repaid loan-asset amount is below `minRepay` unless
+   * the candidate equals `positionCollateral` (i.e., full bad-debt realization),
+   * which is always kept. Returns candidates ordered largest → smallest.
    */
-  private async partialLiquidationCandidates(
-    collateralToken: Address,
+  private partialLiquidationCandidates(
     seizableCollateral: bigint,
     positionCollateral: bigint,
-    minSeizeUsd: number,
-  ): Promise<bigint[]> {
+    market: Market,
+    minRepay: bigint,
+  ): bigint[] {
     const raw = Array.from({ length: 10 }, (_, i) => seizableCollateral / (1n << BigInt(i))).filter(
       (amount, index, arr) => amount > 0n && arr.indexOf(amount) === index,
     );
 
-    if (this.pricers === undefined || this.pricers.length === 0) return raw;
-
-    const kept: bigint[] = [];
-    for (const candidate of raw) {
-      if (candidate === positionCollateral) {
-        kept.push(candidate);
-        continue;
-      }
-      const usdValue = await this.price(collateralToken, candidate, this.pricers);
-      if (usdValue !== undefined && usdValue >= minSeizeUsd) kept.push(candidate);
-    }
-    return kept;
+    return raw.filter((candidate) => {
+      if (candidate === positionCollateral) return true;
+      const repaidShares = market.getLiquidationRepaidShares(candidate);
+      if (repaidShares === undefined) return false;
+      const repaidAssets = market.toBorrowAssets(repaidShares);
+      return repaidAssets >= minRepay;
+    });
   }
 
-  private async handleTx(
+  /**
+   * Simulates the full executor call, then runs the profitability check.
+   * Returns `true` if profitable (or unconditionally on bad-debt + `alwaysRealizeBadDebt`),
+   * `false` if simulation succeeded but not profitable, `undefined` if simulation reverted.
+   */
+  private async simulateAndCheckProfit(
     encoder: LiquidationEncoder,
     calls: Hex[],
     marketParams: IMarketParams,
     badDebtPosition: boolean,
-  ) {
+  ): Promise<boolean | undefined> {
     const functionData = {
       abi: executorAbi,
       functionName: "exec_606BaXt",
@@ -348,31 +453,34 @@ export class LiquidationBot {
 
     if (results[1].status !== "success") {
       console.warn(`${this.logTag}Transaction failed in simulation: ${results[1].error}`);
-      return;
+      return undefined;
     }
 
-    if (
-      !(await this.checkProfit(
-        marketParams.loanToken,
-        {
-          beforeTx: results[0].result,
-          afterTx: results[2].result,
-        },
-        {
-          used: results[1].gasUsed,
-          price: gasPrice,
-        },
-        badDebtPosition,
-      ))
-    )
-      return false;
+    return this.checkProfit(
+      marketParams.loanToken,
+      {
+        beforeTx: results[0].result,
+        afterTx: results[2].result,
+      },
+      {
+        used: results[1].gasUsed,
+        price: gasPrice,
+      },
+      badDebtPosition,
+    );
+  }
 
-    // TX EXECUTION
+  private async sendLiquidationTx(prepared: PreparedLiquidation): Promise<void> {
+    const functionData = {
+      abi: executorAbi,
+      functionName: "exec_606BaXt",
+      args: [prepared.calls],
+    } as const;
 
     if (this.flashbotAccount) {
       const signedBundle = await Flashbots.signBundle([
         {
-          transaction: { to: encoder.address, ...functionData },
+          transaction: { to: prepared.encoder.address, ...functionData },
           client: this.client,
         },
       ]);
@@ -382,12 +490,10 @@ export class LiquidationBot {
         (await getBlockNumber(this.client)) + 1n,
         this.flashbotAccount,
       );
-      return true;
-    } else {
-      await writeContract(this.client, { address: encoder.address, ...functionData });
+      return;
     }
 
-    return true;
+    await writeContract(this.client, { address: prepared.encoder.address, ...functionData });
   }
 
   private async convertCollateralToLoan(

--- a/apps/client/src/bot.ts
+++ b/apps/client/src/bot.ts
@@ -7,7 +7,6 @@ import {
   ChainAddresses,
   getChainAddresses,
   type IMarketParams,
-  type Market,
   MarketUtils,
   PreLiquidationPosition,
 } from "@morpho-org/blue-sdk";
@@ -60,14 +59,16 @@ export interface LiquidationBotInputs {
   marketsFetchingCooldownMechanism: MarketsFetchingCooldownMechanism;
   flashbotAccount?: LocalAccount;
   /**
-   * Per-loan-asset minimum repaid amount (in loan-asset atoms) for a partial-
-   * liquidation candidate to be considered. When undefined, or when the loan
-   * asset of a given market is not in this submap, the bot falls back to a
-   * single full-seize attempt. When defined and the loan asset is listed, the
-   * bot tries candidate seize amounts `seizableCollateral / 2^i` for i in [0, 10),
-   * keeps those whose repaid loan-asset amount is ≥ this threshold (plus a full
-   * bad-debt seize regardless of threshold), simulates each, and submits the
-   * one with the largest seize amount among the profitable simulations.
+   * Per-loan-asset minimum borrow-assets threshold (in loan-asset atoms). The
+   * threshold acts as a position-level mode switch:
+   *
+   * - Loan asset missing from this submap → single full-seize attempt (legacy).
+   * - Loan asset present, `position.borrowAssets < threshold` → single full-seize
+   *   attempt (regardless of bad-debt status).
+   * - Loan asset present, `position.borrowAssets >= threshold` → partial mode:
+   *   the bot simulates candidate seize amounts `seizableCollateral / 2^i` for
+   *   i in [0, 10) and submits the candidate with the largest seize amount
+   *   among the profitable simulations.
    *
    * This is the per-chain submap from `partialLiquidationMinRepay` in the
    * config package — the launcher slices it by `config.chainId`.
@@ -140,10 +141,9 @@ export class LiquidationBot {
 
     if (!this.checkCooldown(MarketUtils.getMarketId(marketParams), position.user)) return;
 
-    const minRepay = this.partialLiquidationMinRepay?.[getAddress(marketParams.loanToken)];
-
-    if (minRepay === undefined) {
-      // Loan asset not configured for partial liquidation → single full-seize attempt.
+    if (!this.partialLiquidationEnabledFor(marketParams.loanToken, position.borrowAssets)) {
+      // Loan asset not configured, or position's borrow assets are below the threshold:
+      // single full-seize attempt regardless of bad-debt status.
       await this.runSingleLiquidationAttempt(
         position.user,
         marketParams,
@@ -153,14 +153,9 @@ export class LiquidationBot {
       return;
     }
 
-    // Partial liquidation enabled: simulate every candidate, keep the profitable ones,
+    // Partial liquidation: simulate every halving candidate, keep the profitable ones,
     // submit the candidate with the largest seize amount.
-    const candidates = this.partialLiquidationCandidates(
-      fullSeizableCollateral,
-      position.collateral,
-      position.market,
-      minRepay,
-    );
+    const candidates = this.partialLiquidationCandidates(fullSeizableCollateral);
 
     const successes: { seizableCollateral: bigint; prepared: PreparedLiquidation }[] = [];
     for (const seizableCollateral of candidates) {
@@ -283,9 +278,7 @@ export class LiquidationBot {
 
     if (!this.checkCooldown(MarketUtils.getMarketId(marketParams), position.user)) return;
 
-    const minRepay = this.partialLiquidationMinRepay?.[getAddress(marketParams.loanToken)];
-
-    if (minRepay === undefined) {
+    if (!this.partialLiquidationEnabledFor(marketParams.loanToken, position.borrowAssets)) {
       await this.runSinglePreLiquidationAttempt(
         position,
         marketParams,
@@ -294,12 +287,7 @@ export class LiquidationBot {
       return;
     }
 
-    const candidates = this.partialLiquidationCandidates(
-      fullSeizableCollateral,
-      position.collateral,
-      position.market,
-      minRepay,
-    );
+    const candidates = this.partialLiquidationCandidates(fullSeizableCollateral);
 
     const successes: { seizableCollateral: bigint; prepared: PreparedLiquidation }[] = [];
     for (const seizableCollateral of candidates) {
@@ -387,29 +375,26 @@ export class LiquidationBot {
   }
 
   /**
-   * Builds the list of seize-amount candidates to try, from largest to smallest:
-   * `seizableCollateral / 2^i` for i in [0, 10). Filters out duplicates and zero,
-   * and drops candidates whose repaid loan-asset amount is below `minRepay` unless
-   * the candidate equals `positionCollateral` (i.e., full bad-debt realization),
-   * which is always kept. Returns candidates ordered largest → smallest.
+   * Returns true iff this loan asset is configured for partial liquidation on this
+   * chain AND the position's outstanding borrow assets are at or above the threshold.
+   * The threshold acts as a position-level mode switch: smaller positions are always
+   * liquidated in a single full attempt (regardless of bad-debt status); larger ones
+   * go through the candidate-and-pick-biggest path.
    */
-  private partialLiquidationCandidates(
-    seizableCollateral: bigint,
-    positionCollateral: bigint,
-    market: Market,
-    minRepay: bigint,
-  ): bigint[] {
-    const raw = Array.from({ length: 10 }, (_, i) => seizableCollateral / (1n << BigInt(i))).filter(
+  private partialLiquidationEnabledFor(loanToken: Address, positionBorrowAssets: bigint): boolean {
+    const minRepay = this.partialLiquidationMinRepay?.[getAddress(loanToken)];
+    if (minRepay === undefined) return false;
+    return positionBorrowAssets >= minRepay;
+  }
+
+  /**
+   * Builds the list of seize-amount candidates to try, from largest to smallest:
+   * `seizableCollateral / 2^i` for i in [0, 10). Deduped, zero-stripped.
+   */
+  private partialLiquidationCandidates(seizableCollateral: bigint): bigint[] {
+    return Array.from({ length: 10 }, (_, i) => seizableCollateral / (1n << BigInt(i))).filter(
       (amount, index, arr) => amount > 0n && arr.indexOf(amount) === index,
     );
-
-    return raw.filter((candidate) => {
-      if (candidate === positionCollateral) return true;
-      const repaidShares = market.getLiquidationRepaidShares(candidate);
-      if (repaidShares === undefined) return false;
-      const repaidAssets = market.toBorrowAssets(repaidShares);
-      return repaidAssets >= minRepay;
-    });
   }
 
   /**

--- a/apps/client/src/index.ts
+++ b/apps/client/src/index.ts
@@ -3,6 +3,7 @@ import {
   POSITION_LIQUIDATION_COOLDOWN_ENABLED,
   POSITION_LIQUIDATION_COOLDOWN_PERIOD,
   ALWAYS_REALIZE_BAD_DEBT,
+  partialLiquidationMinRepay,
   type ChainConfig,
 } from "@morpho-blue-liquidation-bot/config";
 import type { DataProvider } from "@morpho-blue-liquidation-bot/data-providers";
@@ -78,7 +79,7 @@ export const launchBot = (config: ChainConfig, dataProvider: DataProvider) => {
     positionLiquidationCooldownMechanism,
     flashbotAccount,
     alwaysRealizeBadDebt: ALWAYS_REALIZE_BAD_DEBT,
-    partialLiquidationMinSeizeUsd: config.partialLiquidationMinSeizeUsd,
+    partialLiquidationMinRepay: partialLiquidationMinRepay[config.chainId],
   };
 
   const bot = new LiquidationBot(inputs);

--- a/apps/client/src/index.ts
+++ b/apps/client/src/index.ts
@@ -78,6 +78,7 @@ export const launchBot = (config: ChainConfig, dataProvider: DataProvider) => {
     positionLiquidationCooldownMechanism,
     flashbotAccount,
     alwaysRealizeBadDebt: ALWAYS_REALIZE_BAD_DEBT,
+    partialLiquidationMinSeizeUsd: config.partialLiquidationMinSeizeUsd,
   };
 
   const bot = new LiquidationBot(inputs);
@@ -89,7 +90,7 @@ export const launchBot = (config: ChainConfig, dataProvider: DataProvider) => {
     watchBlocks(client, {
       onBlock: () => {
         if (count % blockInterval === 0) {
-          bot.run().catch((e) => {
+          bot.run().catch((e: unknown) => {
             console.error(`${logTag} uncaught error in bot.run():`, e);
           });
         }
@@ -97,10 +98,7 @@ export const launchBot = (config: ChainConfig, dataProvider: DataProvider) => {
       },
       onError: (error) => {
         const retryDelay = config.watchBlocksRetryDelayMs ?? 5_000;
-        console.error(
-          `${logTag} watchBlocks error, restarting watcher in ${retryDelay}ms:`,
-          error,
-        );
+        console.error(`${logTag} watchBlocks error, restarting watcher in ${retryDelay}ms:`, error);
         setTimeout(startWatching, retryDelay);
       },
     });

--- a/apps/client/src/index.ts
+++ b/apps/client/src/index.ts
@@ -3,7 +3,7 @@ import {
   POSITION_LIQUIDATION_COOLDOWN_ENABLED,
   POSITION_LIQUIDATION_COOLDOWN_PERIOD,
   ALWAYS_REALIZE_BAD_DEBT,
-  partialLiquidationMinRepay,
+  partialLiquidationMinBorrow,
   type ChainConfig,
 } from "@morpho-blue-liquidation-bot/config";
 import type { DataProvider } from "@morpho-blue-liquidation-bot/data-providers";
@@ -79,7 +79,7 @@ export const launchBot = (config: ChainConfig, dataProvider: DataProvider) => {
     positionLiquidationCooldownMechanism,
     flashbotAccount,
     alwaysRealizeBadDebt: ALWAYS_REALIZE_BAD_DEBT,
-    partialLiquidationMinRepay: partialLiquidationMinRepay[config.chainId],
+    partialLiquidationMinBorrow: partialLiquidationMinBorrow[config.chainId],
   };
 
   const bot = new LiquidationBot(inputs);

--- a/apps/client/test/helpers.ts
+++ b/apps/client/test/helpers.ts
@@ -228,6 +228,36 @@ export function mockEtherPrice(
     });
 }
 
+// Permissive Morpho API price mock — every POST /graphql returns both `chains` and an `assets`
+// list containing WETH, the loan token, and the collateral token at the supplied prices. The
+// pricer reads either `data.chains` or `data.assets.items` from the same body, so this single
+// persistent interceptor handles any sequence of init/price calls. Use this for tests that price
+// the collateral token directly (e.g. partial-liquidation candidate filtering), where the call
+// ordering doesn't line up with `mockEtherPrice`'s sequential interceptors.
+export function mockPersistentPrices(args: {
+  etherPriceUsd: number;
+  loanToken: Address;
+  loanTokenPriceUsd?: number;
+  collateralToken: Address;
+  collateralTokenPriceUsd: number;
+}) {
+  nock("https://blue-api.morpho.org")
+    .persist()
+    .post("/graphql")
+    .reply(200, {
+      data: {
+        chains: [{ id: 1 }],
+        assets: {
+          items: [
+            { address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", priceUsd: args.etherPriceUsd },
+            { address: args.loanToken, priceUsd: args.loanTokenPriceUsd ?? 1 },
+            { address: args.collateralToken, priceUsd: args.collateralTokenPriceUsd },
+          ],
+        },
+      },
+    });
+}
+
 async function overwriteCollateral(
   client: AnvilTestClient,
   marketId: Hex,

--- a/apps/client/test/vitest/execution/liquidation.test.ts
+++ b/apps/client/test/vitest/execution/liquidation.test.ts
@@ -4,10 +4,13 @@ import {
   UniswapV3Venue,
   Erc4626,
   PendlePTVenue,
+  type LiquidityVenue,
+  type ToConvert,
 } from "@morpho-blue-liquidation-bot/liquidity-venues";
 import { MorphoApi } from "@morpho-blue-liquidation-bot/pricers";
+import type { ExecutorEncoder } from "executooor-viem";
 import nock from "nock";
-import { erc20Abi, parseUnits } from "viem";
+import { type Address, erc20Abi, parseUnits } from "viem";
 import { readContract } from "viem/actions";
 import { mainnet } from "viem/chains";
 import { beforeEach, describe, expect } from "vitest";
@@ -19,7 +22,13 @@ import {
   PositionLiquidationCooldownMechanism,
 } from "../../../src/utils/cooldownMechanisms.js";
 import { MORPHO, wbtcUSDC, ptsUSDeUSDC, WETH, borrower } from "../../constants.js";
-import { OneInchTest, setupPosition, mockEtherPrice, syncTimestamp } from "../../helpers.js";
+import {
+  OneInchTest,
+  setupPosition,
+  mockEtherPrice,
+  mockPersistentPrices,
+  syncTimestamp,
+} from "../../helpers.js";
 import { encoderTest, pendleOneInchExecutionTest } from "../../setup.js";
 
 describe("execute liquidation swapping on Uniswap V3", () => {
@@ -569,6 +578,337 @@ describe("profitability checks skipped when no pricers", () => {
       });
 
       // Position should be cleared despite no profitability check
+      expect(positionPostLiquidation[0]).toBe(0n);
+      expect(positionPostLiquidation[1]).toBe(0n);
+      expect(positionPostLiquidation[2]).toBe(0n);
+    },
+  );
+});
+
+// A venue that gates an inner venue by srcAmount. Any conversion above `limit` throws,
+// forcing the bot to try a smaller seize candidate. Below the limit it delegates to `inner`.
+class SizeLimitedSwapVenue implements LiquidityVenue {
+  constructor(
+    private readonly limit: bigint,
+    private readonly inner: LiquidityVenue,
+  ) {}
+  supportsRoute(encoder: ExecutorEncoder, src: Address, dst: Address) {
+    return this.inner.supportsRoute(encoder, src, dst);
+  }
+  async convert(encoder: ExecutorEncoder, toConvert: ToConvert) {
+    if (toConvert.srcAmount > this.limit) throw new Error("size exceeds limit");
+    return this.inner.convert(encoder, toConvert);
+  }
+}
+
+describe("execute partial liquidation", () => {
+  const erc4626 = new Erc4626();
+  const uniswapV3 = new UniswapV3Venue();
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  encoderTest.sequential(
+    "should still liquidate at full size when partialLiquidationMinSeizeUsd is set and full is profitable",
+    async ({ encoder }) => {
+      const pricer = new MorphoApi();
+
+      const { client } = encoder;
+      const collateralAmount = parseUnits("0.1", 8);
+      const borrowAmount = parseUnits("5000", 6);
+
+      const _marketParams = await readContract(encoder.client, {
+        address: MORPHO,
+        abi: morphoBlueAbi,
+        functionName: "idToMarketParams",
+        args: [wbtcUSDC],
+      });
+
+      const marketParams = {
+        loanToken: _marketParams[0],
+        collateralToken: _marketParams[1],
+        oracle: _marketParams[2],
+        irm: _marketParams[3],
+        lltv: _marketParams[4],
+      };
+
+      await setupPosition(client, marketParams, collateralAmount, borrowAmount);
+      mockPersistentPrices({
+        etherPriceUsd: 2640,
+        loanToken: marketParams.loanToken,
+        collateralToken: marketParams.collateralToken,
+        // wBTC at ~$60k at fork block 21_000_000.
+        collateralTokenPriceUsd: 60_000,
+      });
+
+      const bot = new LiquidationBot({
+        logTag: "test client",
+        chainId: mainnet.id,
+        client,
+        wNative: WETH,
+        vaultWhitelist: [],
+        additionalMarketsWhitelist: [wbtcUSDC],
+        executorAddress: encoder.address,
+        treasuryAddress: client.account.address,
+        dataProvider: new MorphoApiDataProvider(),
+        liquidityVenues: [erc4626, uniswapV3],
+        pricers: [pricer],
+        marketsFetchingCooldownMechanism: new MarketsFetchingCooldownMechanism(
+          MARKETS_FETCHING_COOLDOWN_PERIOD,
+        ),
+        alwaysRealizeBadDebt: false,
+        partialLiquidationMinSeizeUsd: 100,
+      });
+
+      await bot.run();
+
+      const positionPostLiquidation = await readContract(client, {
+        address: MORPHO,
+        abi: morphoBlueAbi,
+        functionName: "position",
+        args: [wbtcUSDC, borrower.address],
+      });
+
+      const accountBalance = await readContract(client, {
+        address: marketParams.loanToken,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [client.account.address],
+      });
+
+      // First (largest) candidate succeeds → full position cleared.
+      expect(accountBalance).toBeGreaterThan(0n);
+      expect(positionPostLiquidation[0]).toBe(0n);
+      expect(positionPostLiquidation[1]).toBe(0n);
+      expect(positionPostLiquidation[2]).toBe(0n);
+    },
+  );
+
+  encoderTest.sequential(
+    "should liquidate a smaller candidate when the full seize fails on the venue",
+    async ({ encoder }) => {
+      const pricer = new MorphoApi();
+
+      const { client } = encoder;
+      const collateralAmount = parseUnits("0.1", 8);
+      const borrowAmount = parseUnits("5000", 6);
+
+      const _marketParams = await readContract(encoder.client, {
+        address: MORPHO,
+        abi: morphoBlueAbi,
+        functionName: "idToMarketParams",
+        args: [wbtcUSDC],
+      });
+
+      const marketParams = {
+        loanToken: _marketParams[0],
+        collateralToken: _marketParams[1],
+        oracle: _marketParams[2],
+        irm: _marketParams[3],
+        lltv: _marketParams[4],
+      };
+
+      await setupPosition(client, marketParams, collateralAmount, borrowAmount);
+      mockPersistentPrices({
+        etherPriceUsd: 2640,
+        loanToken: marketParams.loanToken,
+        collateralToken: marketParams.collateralToken,
+        // wBTC at ~$60k at fork block 21_000_000.
+        collateralTokenPriceUsd: 60_000,
+      });
+
+      // Cap any swap above ~0.005 wBTC. Forces the bot to halve until it fits.
+      const limitedVenue = new SizeLimitedSwapVenue(parseUnits("0.005", 8), uniswapV3);
+
+      const bot = new LiquidationBot({
+        logTag: "test client",
+        chainId: mainnet.id,
+        client,
+        wNative: WETH,
+        vaultWhitelist: [],
+        additionalMarketsWhitelist: [wbtcUSDC],
+        executorAddress: encoder.address,
+        treasuryAddress: client.account.address,
+        dataProvider: new MorphoApiDataProvider(),
+        liquidityVenues: [erc4626, limitedVenue],
+        pricers: [pricer],
+        marketsFetchingCooldownMechanism: new MarketsFetchingCooldownMechanism(
+          MARKETS_FETCHING_COOLDOWN_PERIOD,
+        ),
+        alwaysRealizeBadDebt: false,
+        partialLiquidationMinSeizeUsd: 100,
+      });
+
+      await bot.run();
+
+      const positionPostLiquidation = await readContract(client, {
+        address: MORPHO,
+        abi: morphoBlueAbi,
+        functionName: "position",
+        args: [wbtcUSDC, borrower.address],
+      });
+
+      const accountBalance = await readContract(client, {
+        address: marketParams.loanToken,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [client.account.address],
+      });
+
+      // A fractional liquidation succeeded → some loan token sits with the EOA.
+      expect(accountBalance).toBeGreaterThan(0n);
+      // The position is NOT fully cleared (only a fraction was seized).
+      expect(positionPostLiquidation[2]).toBeGreaterThan(0n);
+    },
+  );
+
+  encoderTest.sequential(
+    "should not liquidate when every non-bad-debt candidate is below the USD threshold",
+    async ({ encoder }) => {
+      const pricer = new MorphoApi();
+
+      const { client } = encoder;
+      // Non-bad-debt liquidatable position: collateral $3.25k post-halving > debt $2.9k,
+      // but LTV ~89% > LLTV 86% so the position is liquidatable. seizableCollateral is a
+      // strict fraction of position.collateral → the bad-debt exception in the candidate
+      // filter does NOT kick in.
+      const collateralAmount = parseUnits("0.1", 8);
+      const borrowAmount = parseUnits("2900", 6);
+
+      const _marketParams = await readContract(encoder.client, {
+        address: MORPHO,
+        abi: morphoBlueAbi,
+        functionName: "idToMarketParams",
+        args: [wbtcUSDC],
+      });
+
+      const marketParams = {
+        loanToken: _marketParams[0],
+        collateralToken: _marketParams[1],
+        oracle: _marketParams[2],
+        irm: _marketParams[3],
+        lltv: _marketParams[4],
+      };
+
+      await setupPosition(client, marketParams, collateralAmount, borrowAmount);
+      mockPersistentPrices({
+        etherPriceUsd: 2640,
+        loanToken: marketParams.loanToken,
+        collateralToken: marketParams.collateralToken,
+        // wBTC at ~$60k at fork block 21_000_000.
+        collateralTokenPriceUsd: 60_000,
+      });
+
+      const bot = new LiquidationBot({
+        logTag: "test client",
+        chainId: mainnet.id,
+        client,
+        wNative: WETH,
+        vaultWhitelist: [],
+        additionalMarketsWhitelist: [wbtcUSDC],
+        executorAddress: encoder.address,
+        treasuryAddress: client.account.address,
+        dataProvider: new MorphoApiDataProvider(),
+        liquidityVenues: [erc4626, uniswapV3],
+        pricers: [pricer],
+        marketsFetchingCooldownMechanism: new MarketsFetchingCooldownMechanism(
+          MARKETS_FETCHING_COOLDOWN_PERIOD,
+        ),
+        alwaysRealizeBadDebt: false,
+        // Threshold deliberately higher than this whole position's USD value
+        // (0.05 wBTC ≈ ~$3k at fork) so no candidate clears the floor.
+        // Position is not bad debt either (LLTV not exhausted), so the
+        // bad-debt-exception keep-clause does not apply.
+        partialLiquidationMinSeizeUsd: 1_000_000_000,
+      });
+
+      await bot.run();
+
+      const positionPostLiquidation = await readContract(client, {
+        address: MORPHO,
+        abi: morphoBlueAbi,
+        functionName: "position",
+        args: [wbtcUSDC, borrower.address],
+      });
+
+      const accountBalance = await readContract(client, {
+        address: marketParams.loanToken,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [client.account.address],
+      });
+
+      // Nothing was liquidated.
+      expect(accountBalance).toBe(0n);
+      expect(positionPostLiquidation[2]).toBe(collateralAmount / 2n);
+    },
+  );
+
+  encoderTest.sequential(
+    "should still seize the full amount on a bad-debt position even when below the threshold",
+    async ({ encoder }) => {
+      const pricer = new MorphoApi();
+
+      const { client } = encoder;
+      // Tiny position — full seize is bad debt and USD value sits below any normal threshold.
+      const collateralAmount = parseUnits("0.0001", 8);
+      const borrowAmount = parseUnits("5", 6);
+
+      const _marketParams = await readContract(encoder.client, {
+        address: MORPHO,
+        abi: morphoBlueAbi,
+        functionName: "idToMarketParams",
+        args: [wbtcUSDC],
+      });
+
+      const marketParams = {
+        loanToken: _marketParams[0],
+        collateralToken: _marketParams[1],
+        oracle: _marketParams[2],
+        irm: _marketParams[3],
+        lltv: _marketParams[4],
+      };
+
+      await setupPosition(client, marketParams, collateralAmount, borrowAmount);
+      mockPersistentPrices({
+        etherPriceUsd: 2640,
+        loanToken: marketParams.loanToken,
+        collateralToken: marketParams.collateralToken,
+        // wBTC at ~$60k at fork block 21_000_000.
+        collateralTokenPriceUsd: 60_000,
+      });
+
+      const bot = new LiquidationBot({
+        logTag: "test client",
+        chainId: mainnet.id,
+        client,
+        wNative: WETH,
+        vaultWhitelist: [],
+        additionalMarketsWhitelist: [wbtcUSDC],
+        executorAddress: encoder.address,
+        treasuryAddress: client.account.address,
+        dataProvider: new MorphoApiDataProvider(),
+        liquidityVenues: [erc4626, uniswapV3],
+        pricers: [pricer],
+        marketsFetchingCooldownMechanism: new MarketsFetchingCooldownMechanism(
+          MARKETS_FETCHING_COOLDOWN_PERIOD,
+        ),
+        // Required for the bot to actually send the (unprofitable) bad-debt tx.
+        alwaysRealizeBadDebt: true,
+        partialLiquidationMinSeizeUsd: 1_000_000_000,
+      });
+
+      await bot.run();
+
+      const positionPostLiquidation = await readContract(client, {
+        address: MORPHO,
+        abi: morphoBlueAbi,
+        functionName: "position",
+        args: [wbtcUSDC, borrower.address],
+      });
+
+      // Bad debt: full seize bypasses the USD filter, alwaysRealizeBadDebt clears profit check.
       expect(positionPostLiquidation[0]).toBe(0n);
       expect(positionPostLiquidation[1]).toBe(0n);
       expect(positionPostLiquidation[2]).toBe(0n);

--- a/apps/client/test/vitest/execution/liquidation.test.ts
+++ b/apps/client/test/vitest/execution/liquidation.test.ts
@@ -610,7 +610,7 @@ describe("execute partial liquidation", () => {
   });
 
   encoderTest.sequential(
-    "should still liquidate at full size when partialLiquidationMinSeizeUsd is set and full is profitable",
+    "should still liquidate at full size when partialLiquidationMinRepay is set and full is profitable",
     async ({ encoder }) => {
       const pricer = new MorphoApi();
 
@@ -658,7 +658,7 @@ describe("execute partial liquidation", () => {
           MARKETS_FETCHING_COOLDOWN_PERIOD,
         ),
         alwaysRealizeBadDebt: false,
-        partialLiquidationMinSeizeUsd: 100,
+        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000n },
       });
 
       await bot.run();
@@ -737,7 +737,7 @@ describe("execute partial liquidation", () => {
           MARKETS_FETCHING_COOLDOWN_PERIOD,
         ),
         alwaysRealizeBadDebt: false,
-        partialLiquidationMinSeizeUsd: 100,
+        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000n },
       });
 
       await bot.run();
@@ -820,7 +820,7 @@ describe("execute partial liquidation", () => {
         // (0.05 wBTC ≈ ~$3k at fork) so no candidate clears the floor.
         // Position is not bad debt either (LLTV not exhausted), so the
         // bad-debt-exception keep-clause does not apply.
-        partialLiquidationMinSeizeUsd: 1_000_000_000,
+        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000_000_000_000n },
       });
 
       await bot.run();
@@ -896,7 +896,7 @@ describe("execute partial liquidation", () => {
         ),
         // Required for the bot to actually send the (unprofitable) bad-debt tx.
         alwaysRealizeBadDebt: true,
-        partialLiquidationMinSeizeUsd: 1_000_000_000,
+        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000_000_000_000n },
       });
 
       await bot.run();

--- a/apps/client/test/vitest/execution/liquidation.test.ts
+++ b/apps/client/test/vitest/execution/liquidation.test.ts
@@ -610,7 +610,7 @@ describe("execute partial liquidation", () => {
   });
 
   encoderTest.sequential(
-    "should still liquidate at full size when partialLiquidationMinRepay is set and full is profitable",
+    "should still liquidate at full size when partialLiquidationMinBorrow is set and full is profitable",
     async ({ encoder }) => {
       const pricer = new MorphoApi();
 
@@ -658,7 +658,7 @@ describe("execute partial liquidation", () => {
           MARKETS_FETCHING_COOLDOWN_PERIOD,
         ),
         alwaysRealizeBadDebt: false,
-        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000n },
+        partialLiquidationMinBorrow: { [marketParams.loanToken]: 1_000_000n },
       });
 
       await bot.run();
@@ -737,7 +737,7 @@ describe("execute partial liquidation", () => {
           MARKETS_FETCHING_COOLDOWN_PERIOD,
         ),
         alwaysRealizeBadDebt: false,
-        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000n },
+        partialLiquidationMinBorrow: { [marketParams.loanToken]: 1_000_000n },
       });
 
       await bot.run();
@@ -824,7 +824,7 @@ describe("execute partial liquidation", () => {
         alwaysRealizeBadDebt: false,
         // Threshold = 10^15 USDC atoms = ~$10^9. Far above the position's 5_000_000_000n
         // borrow → partial mode is OFF for this position.
-        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000_000_000_000n },
+        partialLiquidationMinBorrow: { [marketParams.loanToken]: 1_000_000_000_000_000n },
       });
 
       await bot.run();
@@ -902,7 +902,7 @@ describe("execute partial liquidation", () => {
         ),
         // Required for the bot to actually send the (unprofitable) bad-debt tx.
         alwaysRealizeBadDebt: true,
-        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000_000_000_000n },
+        partialLiquidationMinBorrow: { [marketParams.loanToken]: 1_000_000_000_000_000n },
       });
 
       await bot.run();
@@ -972,7 +972,7 @@ describe("execute partial liquidation", () => {
         alwaysRealizeBadDebt: true,
         // Map covers WETH only, NOT the market's loan token (USDC). The bot must
         // fall back to a single full-seize attempt.
-        partialLiquidationMinRepay: { [WETH]: 1n },
+        partialLiquidationMinBorrow: { [WETH]: 1n },
       });
 
       await bot.run();

--- a/apps/client/test/vitest/execution/liquidation.test.ts
+++ b/apps/client/test/vitest/execution/liquidation.test.ts
@@ -764,17 +764,17 @@ describe("execute partial liquidation", () => {
   );
 
   encoderTest.sequential(
-    "should not liquidate when every non-bad-debt candidate is below the USD threshold",
+    "should fall back to a single full-seize attempt when position borrow is below the partial threshold",
     async ({ encoder }) => {
       const pricer = new MorphoApi();
 
       const { client } = encoder;
-      // Non-bad-debt liquidatable position: collateral $3.25k post-halving > debt $2.9k,
-      // but LTV ~89% > LLTV 86% so the position is liquidatable. seizableCollateral is a
-      // strict fraction of position.collateral → the bad-debt exception in the candidate
-      // filter does NOT kick in.
+      // Liquidatable wBTC/USDC position (0.1 wBTC supply → 0.05 wBTC after halving,
+      // 5000 USDC debt). borrowAssets ≈ 5_000_000_000n atoms is well below the absurd
+      // 10^15 threshold below, so the position is NOT partialised — the bot tries only
+      // a single full-seize attempt.
       const collateralAmount = parseUnits("0.1", 8);
-      const borrowAmount = parseUnits("2900", 6);
+      const borrowAmount = parseUnits("5000", 6);
 
       const _marketParams = await readContract(encoder.client, {
         address: MORPHO,
@@ -800,6 +800,12 @@ describe("execute partial liquidation", () => {
         collateralTokenPriceUsd: 60_000,
       });
 
+      // Same gating venue used in the "smaller candidate wins" test above: it rejects
+      // any conversion > 0.005 wBTC. With partial mode OFF (position below threshold),
+      // the bot only tries the full seize (~0.05 wBTC) → the venue rejects → no
+      // liquidation. There's no fallback to a smaller candidate.
+      const limitedVenue = new SizeLimitedSwapVenue(parseUnits("0.005", 8), uniswapV3);
+
       const bot = new LiquidationBot({
         logTag: "test client",
         chainId: mainnet.id,
@@ -810,16 +816,14 @@ describe("execute partial liquidation", () => {
         executorAddress: encoder.address,
         treasuryAddress: client.account.address,
         dataProvider: new MorphoApiDataProvider(),
-        liquidityVenues: [erc4626, uniswapV3],
+        liquidityVenues: [erc4626, limitedVenue],
         pricers: [pricer],
         marketsFetchingCooldownMechanism: new MarketsFetchingCooldownMechanism(
           MARKETS_FETCHING_COOLDOWN_PERIOD,
         ),
         alwaysRealizeBadDebt: false,
-        // Threshold deliberately higher than this whole position's USD value
-        // (0.05 wBTC ≈ ~$3k at fork) so no candidate clears the floor.
-        // Position is not bad debt either (LLTV not exhausted), so the
-        // bad-debt-exception keep-clause does not apply.
+        // Threshold = 10^15 USDC atoms = ~$10^9. Far above the position's 5_000_000_000n
+        // borrow → partial mode is OFF for this position.
         partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000_000_000_000n },
       });
 
@@ -839,19 +843,21 @@ describe("execute partial liquidation", () => {
         args: [client.account.address],
       });
 
-      // Nothing was liquidated.
+      // Full-seize attempt failed on the gating venue and no partialising happened.
       expect(accountBalance).toBe(0n);
       expect(positionPostLiquidation[2]).toBe(collateralAmount / 2n);
     },
   );
 
   encoderTest.sequential(
-    "should still seize the full amount on a bad-debt position even when below the threshold",
+    "should still seize the full amount on a bad-debt position whose borrow is below the partial threshold",
     async ({ encoder }) => {
       const pricer = new MorphoApi();
 
       const { client } = encoder;
-      // Tiny position — full seize is bad debt and USD value sits below any normal threshold.
+      // Tiny bad-debt position — its 5_000_000n borrow (5 USDC) is far below the partial
+      // threshold, so the bot falls back to a single full-seize attempt and (thanks to
+      // `alwaysRealizeBadDebt`) goes through with the unprofitable bad-debt tx.
       const collateralAmount = parseUnits("0.0001", 8);
       const borrowAmount = parseUnits("5", 6);
 
@@ -908,7 +914,77 @@ describe("execute partial liquidation", () => {
         args: [wbtcUSDC, borrower.address],
       });
 
-      // Bad debt: full seize bypasses the USD filter, alwaysRealizeBadDebt clears profit check.
+      // Below-threshold path used the single full-seize attempt; alwaysRealizeBadDebt
+      // cleared the profitability gate.
+      expect(positionPostLiquidation[0]).toBe(0n);
+      expect(positionPostLiquidation[1]).toBe(0n);
+      expect(positionPostLiquidation[2]).toBe(0n);
+    },
+  );
+
+  encoderTest.sequential(
+    "should fall back to a single full-seize when the market's loan asset is not in the partial-liquidation map",
+    async ({ encoder }) => {
+      const pricer = new MorphoApi();
+
+      const { client } = encoder;
+      const collateralAmount = parseUnits("0.1", 8);
+      const borrowAmount = parseUnits("5000", 6);
+
+      const _marketParams = await readContract(encoder.client, {
+        address: MORPHO,
+        abi: morphoBlueAbi,
+        functionName: "idToMarketParams",
+        args: [wbtcUSDC],
+      });
+
+      const marketParams = {
+        loanToken: _marketParams[0],
+        collateralToken: _marketParams[1],
+        oracle: _marketParams[2],
+        irm: _marketParams[3],
+        lltv: _marketParams[4],
+      };
+
+      await setupPosition(client, marketParams, collateralAmount, borrowAmount);
+      mockPersistentPrices({
+        etherPriceUsd: 2640,
+        loanToken: marketParams.loanToken,
+        collateralToken: marketParams.collateralToken,
+        collateralTokenPriceUsd: 60_000,
+      });
+
+      const bot = new LiquidationBot({
+        logTag: "test client",
+        chainId: mainnet.id,
+        client,
+        wNative: WETH,
+        vaultWhitelist: [],
+        additionalMarketsWhitelist: [wbtcUSDC],
+        executorAddress: encoder.address,
+        treasuryAddress: client.account.address,
+        dataProvider: new MorphoApiDataProvider(),
+        liquidityVenues: [erc4626, uniswapV3],
+        pricers: [pricer],
+        marketsFetchingCooldownMechanism: new MarketsFetchingCooldownMechanism(
+          MARKETS_FETCHING_COOLDOWN_PERIOD,
+        ),
+        alwaysRealizeBadDebt: true,
+        // Map covers WETH only, NOT the market's loan token (USDC). The bot must
+        // fall back to a single full-seize attempt.
+        partialLiquidationMinRepay: { [WETH]: 1n },
+      });
+
+      await bot.run();
+
+      const positionPostLiquidation = await readContract(client, {
+        address: MORPHO,
+        abi: morphoBlueAbi,
+        functionName: "position",
+        args: [wbtcUSDC, borrower.address],
+      });
+
+      // Single full-seize attempt cleared the position.
       expect(positionPostLiquidation[0]).toBe(0n);
       expect(positionPostLiquidation[1]).toBe(0n);
       expect(positionPostLiquidation[2]).toBe(0n);

--- a/apps/client/test/vitest/execution/preLiquidation.test.ts
+++ b/apps/client/test/vitest/execution/preLiquidation.test.ts
@@ -14,7 +14,12 @@ import { preLiquidationFactoryAbi } from "../../../src/abis/morpho/preLiquidatio
 import { LiquidationBot } from "../../../src/bot.js";
 import { MarketsFetchingCooldownMechanism } from "../../../src/utils/cooldownMechanisms.js";
 import { borrower, MORPHO, PRE_LIQUIDATION_FACTORY, WETH, wbtcUSDT } from "../../constants.js";
-import { MockDataProvider, mockEtherPrice, syncTimestamp } from "../../helpers.js";
+import {
+  MockDataProvider,
+  mockEtherPrice,
+  mockPersistentPrices,
+  syncTimestamp,
+} from "../../helpers.js";
 import { preLiquidationTest } from "../../setup.js";
 
 const oracleAbi = [
@@ -233,6 +238,108 @@ describe("execute pre-liquidation", () => {
       });
 
       expect(accountBalance).toBeGreaterThan(0n);
+    },
+  );
+
+  preLiquidationTest.sequential(
+    "should pre-liquidate at full size when partialLiquidationMinSeizeUsd is set and full is profitable",
+    async ({ encoder }) => {
+      const pricer = new MorphoApi();
+      const { client } = encoder;
+
+      const { marketParams, preLiqPosition } = await setupPreLiquidationPosition(client);
+
+      const mockDataProvider = new MockDataProvider();
+      mockDataProvider.setPreLiquidatablePositions([preLiqPosition]);
+      mockPersistentPrices({
+        etherPriceUsd: 2640,
+        loanToken: marketParams.loanToken,
+        collateralToken: marketParams.collateralToken,
+        // wBTC at ~$95k around the preLiquidation fork block.
+        collateralTokenPriceUsd: 95_000,
+      });
+
+      const bot = new LiquidationBot({
+        logTag: "test client",
+        chainId: mainnet.id,
+        client,
+        wNative: WETH,
+        vaultWhitelist: [],
+        additionalMarketsWhitelist: [wbtcUSDT],
+        executorAddress: encoder.address,
+        treasuryAddress: client.account.address,
+        dataProvider: mockDataProvider,
+        liquidityVenues: [erc4626, uniswapV3],
+        pricers: [pricer],
+        marketsFetchingCooldownMechanism: new MarketsFetchingCooldownMechanism(
+          MARKETS_FETCHING_COOLDOWN_PERIOD,
+        ),
+        alwaysRealizeBadDebt: false,
+        partialLiquidationMinSeizeUsd: 10,
+      });
+
+      await bot.run();
+
+      const accountBalance = await readContract(client, {
+        address: marketParams.loanToken,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [client.account.address],
+      });
+
+      // First (largest) candidate succeeded → pre-liquidation went through.
+      expect(accountBalance).toBeGreaterThan(0n);
+    },
+  );
+
+  preLiquidationTest.sequential(
+    "should skip pre-liquidation when every candidate is below the USD threshold",
+    async ({ encoder }) => {
+      const pricer = new MorphoApi();
+      const { client } = encoder;
+
+      const { marketParams, preLiqPosition } = await setupPreLiquidationPosition(client);
+
+      const mockDataProvider = new MockDataProvider();
+      mockDataProvider.setPreLiquidatablePositions([preLiqPosition]);
+      mockPersistentPrices({
+        etherPriceUsd: 2640,
+        loanToken: marketParams.loanToken,
+        collateralToken: marketParams.collateralToken,
+        collateralTokenPriceUsd: 95_000,
+      });
+
+      const bot = new LiquidationBot({
+        logTag: "test client",
+        chainId: mainnet.id,
+        client,
+        wNative: WETH,
+        vaultWhitelist: [],
+        additionalMarketsWhitelist: [wbtcUSDT],
+        executorAddress: encoder.address,
+        treasuryAddress: client.account.address,
+        dataProvider: mockDataProvider,
+        liquidityVenues: [erc4626, uniswapV3],
+        pricers: [pricer],
+        marketsFetchingCooldownMechanism: new MarketsFetchingCooldownMechanism(
+          MARKETS_FETCHING_COOLDOWN_PERIOD,
+        ),
+        alwaysRealizeBadDebt: false,
+        // Threshold well above the pre-liquidatable position's USD value.
+        partialLiquidationMinSeizeUsd: 1_000_000_000,
+      });
+
+      await bot.run();
+
+      const accountBalance = await readContract(client, {
+        address: marketParams.loanToken,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [client.account.address],
+      });
+
+      // No candidate survived the USD filter → no pre-liquidation attempted.
+      expect(accountBalance).toBe(0n);
     },
   );
 });

--- a/apps/client/test/vitest/execution/preLiquidation.test.ts
+++ b/apps/client/test/vitest/execution/preLiquidation.test.ts
@@ -293,7 +293,7 @@ describe("execute pre-liquidation", () => {
   );
 
   preLiquidationTest.sequential(
-    "should skip pre-liquidation when every candidate is below the USD threshold",
+    "should fall back to a single full-seize pre-liquidation when position borrow is below the partial threshold",
     async ({ encoder }) => {
       const pricer = new MorphoApi();
       const { client } = encoder;
@@ -325,7 +325,8 @@ describe("execute pre-liquidation", () => {
           MARKETS_FETCHING_COOLDOWN_PERIOD,
         ),
         alwaysRealizeBadDebt: false,
-        // Threshold well above the pre-liquidatable position's USD value.
+        // Threshold well above the position's borrow assets → partial mode is OFF for this
+        // position, the bot falls back to a single full-seize pre-liquidation.
         partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000_000_000_000n },
       });
 
@@ -338,8 +339,8 @@ describe("execute pre-liquidation", () => {
         args: [client.account.address],
       });
 
-      // No candidate survived the USD filter → no pre-liquidation attempted.
-      expect(accountBalance).toBe(0n);
+      // Single full-seize pre-liquidation went through.
+      expect(accountBalance).toBeGreaterThan(0n);
     },
   );
 });

--- a/apps/client/test/vitest/execution/preLiquidation.test.ts
+++ b/apps/client/test/vitest/execution/preLiquidation.test.ts
@@ -242,7 +242,7 @@ describe("execute pre-liquidation", () => {
   );
 
   preLiquidationTest.sequential(
-    "should pre-liquidate at full size when partialLiquidationMinSeizeUsd is set and full is profitable",
+    "should pre-liquidate at full size when partialLiquidationMinRepay is set and full is profitable",
     async ({ encoder }) => {
       const pricer = new MorphoApi();
       const { client } = encoder;
@@ -275,7 +275,7 @@ describe("execute pre-liquidation", () => {
           MARKETS_FETCHING_COOLDOWN_PERIOD,
         ),
         alwaysRealizeBadDebt: false,
-        partialLiquidationMinSeizeUsd: 10,
+        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000n },
       });
 
       await bot.run();
@@ -326,7 +326,7 @@ describe("execute pre-liquidation", () => {
         ),
         alwaysRealizeBadDebt: false,
         // Threshold well above the pre-liquidatable position's USD value.
-        partialLiquidationMinSeizeUsd: 1_000_000_000,
+        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000_000_000_000n },
       });
 
       await bot.run();

--- a/apps/client/test/vitest/execution/preLiquidation.test.ts
+++ b/apps/client/test/vitest/execution/preLiquidation.test.ts
@@ -242,7 +242,7 @@ describe("execute pre-liquidation", () => {
   );
 
   preLiquidationTest.sequential(
-    "should pre-liquidate at full size when partialLiquidationMinRepay is set and full is profitable",
+    "should pre-liquidate at full size when partialLiquidationMinBorrow is set and full is profitable",
     async ({ encoder }) => {
       const pricer = new MorphoApi();
       const { client } = encoder;
@@ -275,7 +275,7 @@ describe("execute pre-liquidation", () => {
           MARKETS_FETCHING_COOLDOWN_PERIOD,
         ),
         alwaysRealizeBadDebt: false,
-        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000n },
+        partialLiquidationMinBorrow: { [marketParams.loanToken]: 1_000_000n },
       });
 
       await bot.run();
@@ -327,7 +327,7 @@ describe("execute pre-liquidation", () => {
         alwaysRealizeBadDebt: false,
         // Threshold well above the position's borrow assets → partial mode is OFF for this
         // position, the bot falls back to a single full-seize pre-liquidation.
-        partialLiquidationMinRepay: { [marketParams.loanToken]: 1_000_000_000_000_000n },
+        partialLiquidationMinBorrow: { [marketParams.loanToken]: 1_000_000_000_000_000n },
       });
 
       await bot.run();

--- a/apps/config/src/index.ts
+++ b/apps/config/src/index.ts
@@ -63,6 +63,7 @@ export {
 };
 export * from "./dataProviders";
 export * from "./liquidityVenues";
+export * from "./partialLiquidation";
 export * from "./pricers";
 export {
   POSITION_LIQUIDATION_COOLDOWN_PERIOD,

--- a/apps/config/src/partialLiquidation.ts
+++ b/apps/config/src/partialLiquidation.ts
@@ -5,4 +5,4 @@ import type { Address } from "viem";
  * position into partial-liquidation mode. See the "Partial Liquidation"
  * section of the root README for full semantics.
  */
-export const partialLiquidationMinRepay: Record<number, Partial<Record<Address, bigint>>> = {};
+export const partialLiquidationMinBorrow: Record<number, Partial<Record<Address, bigint>>> = {};

--- a/apps/config/src/partialLiquidation.ts
+++ b/apps/config/src/partialLiquidation.ts
@@ -1,24 +1,8 @@
 import type { Address } from "viem";
 
 /**
- * Per-chain × per-loan-asset minimum borrow-assets threshold (in loan-asset atoms)
- * that switches a position into partial-liquidation mode.
- *
- * Semantics:
- * - A chain absent from this map: partial liquidation is disabled for that chain;
- *   every liquidatable position is attempted as a single full seize (legacy).
- * - A chain present but a loan asset absent from its submap: positions in markets
- *   with that loan asset are also attempted as a single full seize.
- * - A chain present AND the market's `loanToken` listed:
- *   - If `position.borrowAssets < threshold` → single full-seize attempt
- *     (regardless of bad-debt status — small positions are never partialised).
- *   - If `position.borrowAssets >= threshold` → partial mode: the bot simulates
- *     candidate seize amounts `seizableCollateral / 2^i` for i in [0, 10) and
- *     submits the candidate with the LARGEST seize amount among the simulations
- *     that pass the profitability check.
- *
- * Values are in the loan asset's smallest unit (atoms). For USDC (6 decimals)
- * `100_000_000n` = 100 USDC; for DAI (18 decimals) `100_000_000_000_000_000_000n`
- * = 100 DAI.
+ * Per-chain × per-loan-asset threshold (in loan-asset atoms) that switches a
+ * position into partial-liquidation mode. See the "Partial Liquidation"
+ * section of the root README for full semantics.
  */
 export const partialLiquidationMinRepay: Record<number, Partial<Record<Address, bigint>>> = {};

--- a/apps/config/src/partialLiquidation.ts
+++ b/apps/config/src/partialLiquidation.ts
@@ -1,22 +1,21 @@
 import type { Address } from "viem";
 
 /**
- * Per-chain × per-loan-asset minimum loan-asset amount (in atoms) that a
- * partial-liquidation candidate must repay to be considered.
+ * Per-chain × per-loan-asset minimum borrow-assets threshold (in loan-asset atoms)
+ * that switches a position into partial-liquidation mode.
  *
  * Semantics:
- * - A chain is "partial-liquidation enabled" if it has an entry in this map.
- *   Chains absent from this map only ever try a single full-seize attempt
- *   (the legacy behavior).
- * - For an enabled chain, a market is "partial-liquidation enabled" only if
- *   its `loanToken` appears in the chain's submap. Markets with a loan token
- *   not listed here fall back to a single full-seize attempt.
- * - For a partial-liquidation-enabled market, the bot tries candidate seize
- *   amounts `seizableCollateral / 2^i` for i in [0, 10). Each candidate's
- *   repaid loan-asset amount must be ≥ this threshold to be tried — except
- *   a full bad-debt seize (candidate equals the position's collateral), which
- *   is always tried. Among candidates that pass simulation and profitability,
- *   the one with the LARGEST seize amount is submitted.
+ * - A chain absent from this map: partial liquidation is disabled for that chain;
+ *   every liquidatable position is attempted as a single full seize (legacy).
+ * - A chain present but a loan asset absent from its submap: positions in markets
+ *   with that loan asset are also attempted as a single full seize.
+ * - A chain present AND the market's `loanToken` listed:
+ *   - If `position.borrowAssets < threshold` → single full-seize attempt
+ *     (regardless of bad-debt status — small positions are never partialised).
+ *   - If `position.borrowAssets >= threshold` → partial mode: the bot simulates
+ *     candidate seize amounts `seizableCollateral / 2^i` for i in [0, 10) and
+ *     submits the candidate with the LARGEST seize amount among the simulations
+ *     that pass the profitability check.
  *
  * Values are in the loan asset's smallest unit (atoms). For USDC (6 decimals)
  * `100_000_000n` = 100 USDC; for DAI (18 decimals) `100_000_000_000_000_000_000n`

--- a/apps/config/src/partialLiquidation.ts
+++ b/apps/config/src/partialLiquidation.ts
@@ -1,0 +1,25 @@
+import type { Address } from "viem";
+
+/**
+ * Per-chain × per-loan-asset minimum loan-asset amount (in atoms) that a
+ * partial-liquidation candidate must repay to be considered.
+ *
+ * Semantics:
+ * - A chain is "partial-liquidation enabled" if it has an entry in this map.
+ *   Chains absent from this map only ever try a single full-seize attempt
+ *   (the legacy behavior).
+ * - For an enabled chain, a market is "partial-liquidation enabled" only if
+ *   its `loanToken` appears in the chain's submap. Markets with a loan token
+ *   not listed here fall back to a single full-seize attempt.
+ * - For a partial-liquidation-enabled market, the bot tries candidate seize
+ *   amounts `seizableCollateral / 2^i` for i in [0, 10). Each candidate's
+ *   repaid loan-asset amount must be ≥ this threshold to be tried — except
+ *   a full bad-debt seize (candidate equals the position's collateral), which
+ *   is always tried. Among candidates that pass simulation and profitability,
+ *   the one with the LARGEST seize amount is submitted.
+ *
+ * Values are in the loan asset's smallest unit (atoms). For USDC (6 decimals)
+ * `100_000_000n` = 100 USDC; for DAI (18 decimals) `100_000_000_000_000_000_000n`
+ * = 100 DAI.
+ */
+export const partialLiquidationMinRepay: Record<number, Partial<Record<Address, bigint>>> = {};

--- a/apps/config/src/types.ts
+++ b/apps/config/src/types.ts
@@ -31,14 +31,6 @@ export interface Options {
   useFlashbots: boolean;
   blockInterval?: number;
   watchBlocksRetryDelayMs?: number;
-  /**
-   * When set, enables partial liquidation: the bot tries candidate seize amounts
-   * `seizableCollateral / 2^i` for i in [0, 10) from largest to smallest, skipping
-   * any candidate whose collateral USD value is below this threshold (except a
-   * full bad-debt seize, which is always tried). Submits the first profitable
-   * candidate. Undefined disables the feature (single-attempt legacy behavior).
-   */
-  partialLiquidationMinSeizeUsd?: number;
 }
 
 export type ChainConfig = Omit<Config, "options"> &

--- a/apps/config/src/types.ts
+++ b/apps/config/src/types.ts
@@ -31,6 +31,14 @@ export interface Options {
   useFlashbots: boolean;
   blockInterval?: number;
   watchBlocksRetryDelayMs?: number;
+  /**
+   * When set, enables partial liquidation: the bot tries candidate seize amounts
+   * `seizableCollateral / 2^i` for i in [0, 10) from largest to smallest, skipping
+   * any candidate whose collateral USD value is below this threshold (except a
+   * full bad-debt seize, which is always tried). Submits the first profitable
+   * candidate. Undefined disables the feature (single-attempt legacy behavior).
+   */
+  partialLiquidationMinSeizeUsd?: number;
 }
 
 export type ChainConfig = Omit<Config, "options"> &

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,9 +3,9 @@ packages:
   - "apps/*"
 
 allowBuilds:
-  esbuild: set this to true or false
-  keccak: set this to true or false
-  rescript: set this to true or false
+  esbuild: true
+  keccak: true
+  rescript: true
 
 # 3 days (4320 minutes) — delay newly published packages to reduce supply-chain risk.
 minimumReleaseAge: 4320


### PR DESCRIPTION
## Summary

- Adds `partialLiquidationMinSeizeUsd?: number` to per-chain `Options`. When set, the bot tries candidate seize amounts `seizableCollateral / 2^i` for i=0..9 largest-first, skipping any whose collateral USD value is below the threshold (except a full bad-debt seize, which is always tried). First profitable candidate is submitted. Undefined disables — single-attempt legacy behavior.
- Mirrors the partial-liquidation pattern from the [SDK example](https://github.com/morpho-org/sdks/blob/main/packages/liquidation-sdk-viem/examples/whitelistedMarkets.ts#L138-L140).
- Applies to both `LiquidationBot.liquidate()` and `preLiquidate()`.
- CI fixes (action SHA pins, pnpm `allowBuilds`, Foundry 1.5.1) cherry-picked from the 0x branch so this can run green on top of `main`.

## Test plan

- [x] `pnpm test:client` locally: 16/16 pass (4 new in `liquidation.test.ts`, 2 new in `preLiquidation.test.ts`).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)