### PR TITLE
fix(flashbots): encode calldata and attach gasPrice to bundle transaction

### DIFF
--- a/apps/client/src/bot.ts
+++ b/apps/client/src/bot.ts
@@ -25,6 +25,7 @@ import {
   type Transport,
   type WalletClient,
 } from "viem";
+import { encodeFunctionData } from "viem";
 import {
   getBlockNumber,
   getGasPrice,
@@ -277,7 +278,11 @@ export class LiquidationBot {
     if (this.flashbotAccount) {
       const signedBundle = await Flashbots.signBundle([
         {
-          transaction: { to: encoder.address, ...functionData },
+          transaction: {
+            to: encoder.address,
+            data: encodeFunctionData(functionData),
+            gasPrice,
+          },
           client: this.client,
         },
       ]);


### PR DESCRIPTION
## Problem

Closes #114

The Flashbots bundle transaction in `LiquidationBot.handleTx` was built 
incorrectly, causing liquidations on any chain with `useFlashbots: true` 
to never execute.
Two bugs in `apps/client/src/bot.ts`:

**1. Missing `data` field**
Spreading `functionData` (which contains `abi`, `functionName`, `args`) 
into the transaction object does not produce an encoded `data` field. 
The calldata for `exec_606BaXt(calls)` was never attached to the tx, 
so the bundle was essentially a no-op.

**2. Missing `gasPrice`**
Without a `gasPrice` field, viem cannot infer the transaction type during 
serialization and throws `InvalidSerializableTransactionError`, causing 
`signBundle` to fail entirely.

## Fix

- Explicitly encode calldata using `encodeFunctionData(functionData)` 
  (imported from `viem`)
- Reuse `gasPrice` already fetched earlier in `handleTx` for the 
  profit check — no extra RPC call needed

## Changes

- `apps/client/src/bot.ts` — fixed bundle tx construction + added 
  `encodeFunctionData` import