### PR TITLE
[codex] Batch Morpho API pricing

### DIFF
--- a/apps/client/src/bot.ts
+++ b/apps/client/src/bot.ts
@@ -37,7 +37,7 @@ import {
   MarketsFetchingCooldownMechanism,
   PositionLiquidationCooldownMechanism,
 } from "./utils/cooldownMechanisms.js";
-import { fetchWhitelistedVaults } from "./utils/fetch-whitelisted-vaults.js";
+import { fetchListedVaults } from "./utils/fetch-listed-vaults.js";
 import { Flashbots } from "./utils/flashbots.js";
 import { LiquidationEncoder } from "./utils/LiquidationEncoder.js";
 import { DEFAULT_LIQUIDATION_BUFFER_BPS, WAD, wMulDown } from "./utils/maths.js";
@@ -400,7 +400,7 @@ export class LiquidationBot {
     if (!this.marketsFetchingCooldownMechanism.isFetchingReady()) return;
 
     if (this.vaultWhitelist === "morpho-api")
-      this.vaultWhitelist = await fetchWhitelistedVaults(this.chainId);
+      this.vaultWhitelist = await fetchListedVaults(this.chainId);
 
     const vaultWhitelist = this.vaultWhitelist;
     console.log(`${this.logTag}📝 Watching markets in the following vaults:`, vaultWhitelist);

--- a/apps/client/src/utils/fetch-listed-vaults.ts
+++ b/apps/client/src/utils/fetch-listed-vaults.ts
@@ -1,3 +1,4 @@
+import { MORPHO_API_GRAPHQL_URL } from "@morpho-blue-liquidation-bot/config";
 import { type Address } from "viem";
 
 const QUERY = `
@@ -22,8 +23,8 @@ interface VaultsResponse {
   errors?: { message: string }[];
 }
 
-export async function fetchWhitelistedVaults(chainId: number): Promise<Address[]> {
-  const res = await fetch("https://blue-api.morpho.org/graphql", {
+export async function fetchListedVaults(chainId: number): Promise<Address[]> {
+  const res = await fetch(MORPHO_API_GRAPHQL_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ query: QUERY, variables: { chainIds: [chainId] } }),

--- a/apps/client/test/helpers.ts
+++ b/apps/client/test/helpers.ts
@@ -191,37 +191,21 @@ export function mockEtherPrice(
     lltv: bigint;
   },
 ) {
-  nock("https://blue-api.morpho.org")
-    .post("/graphql")
-    .reply(200, {
-      data: {
-        chains: [{ id: 1 }],
-      },
-    })
-    .post("/graphql")
-    .reply(200, {
-      data: {
-        chains: [{ id: 1 }],
-      },
-    })
-    .post("/graphql")
+  nock("https://api.morpho.org")
+    .post(
+      "/graphql",
+      (body) => body.query?.includes("PriceAssets") && body.variables?.chainId === 1,
+    )
     .reply(200, {
       data: {
         assets: {
           items: [
-            { address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", priceUsd: etherPrice },
-            { address: marketParams.loanToken, priceUsd: 1 },
-          ],
-        },
-      },
-    })
-    .post("/graphql")
-    .reply(200, {
-      data: {
-        assets: {
-          items: [
-            { address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", priceUsd: etherPrice },
-            { address: marketParams.collateralToken, priceUsd: 1 },
+            {
+              address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+              price: { usd: etherPrice },
+            },
+            { address: marketParams.loanToken, price: { usd: 1 } },
+            { address: marketParams.collateralToken, price: { usd: 1 } },
           ],
         },
       },

--- a/apps/config/src/index.ts
+++ b/apps/config/src/index.ts
@@ -4,6 +4,8 @@ import type { Address, Chain, Hex } from "viem";
 import { chainConfigs } from "./config";
 import type { ChainConfig, DataProviderName, LiquidityVenueName, PricerName } from "./types";
 
+export const MORPHO_API_GRAPHQL_URL = "https://api.morpho.org/graphql";
+
 dotenv.config();
 
 export function chainConfig(chainId: number): ChainConfig {

--- a/apps/data-providers/src/morphoApi/api/index.ts
+++ b/apps/data-providers/src/morphoApi/api/index.ts
@@ -1,8 +1,8 @@
-import { BLUE_API_GRAPHQL_URL } from "@morpho-org/morpho-ts";
+import { MORPHO_API_GRAPHQL_URL } from "@morpho-blue-liquidation-bot/config";
 import { GraphQLClient } from "graphql-request";
 
 import { getSdk } from "./sdk.js";
 
 export * as ApiTypes from "./types.js";
 
-export const apiSdk: ReturnType<typeof getSdk> = getSdk(new GraphQLClient(BLUE_API_GRAPHQL_URL));
+export const apiSdk: ReturnType<typeof getSdk> = getSdk(new GraphQLClient(MORPHO_API_GRAPHQL_URL));

--- a/apps/pricers/src/morphoApi/index.ts
+++ b/apps/pricers/src/morphoApi/index.ts
@@ -1,75 +1,127 @@
+import { MORPHO_API_GRAPHQL_URL } from "@morpho-blue-liquidation-bot/config";
 import type { Account, Address, Chain, Client, Transport } from "viem";
 
 import type { Pricer } from "../pricer";
 
+const ASSET_BATCH_SIZE = 30;
+
+interface PendingPriceRequest {
+  asset: Address;
+  resolve: (price: number | undefined) => void;
+}
+
+interface AssetsPriceResponse {
+  data?: {
+    assets?: {
+      items?: {
+        address: Address;
+        price: { usd: number | null } | null;
+      }[];
+    };
+  };
+  errors?: { message: string }[];
+}
+
 export class MorphoApi implements Pricer {
-  private readonly API_URL = "https://blue-api.morpho.org/graphql";
-  private supportedChains: number[] = [];
-  private initialized = false;
+  private readonly pendingRequests = new Map<number, PendingPriceRequest[]>();
+  private readonly scheduledChains = new Set<number>();
 
   async price(client: Client<Transport, Chain, Account>, asset: Address) {
-    if (!this.initialized) {
-      await this.initialize();
-    }
+    const chainId = client.chain.id;
 
-    if (!this.supportedChains.includes(client.chain.id)) return;
+    return new Promise<number | undefined>((resolve) => {
+      const requests = this.pendingRequests.get(chainId) ?? [];
+      requests.push({ asset, resolve });
+      this.pendingRequests.set(chainId, requests);
 
-    try {
-      const response = await fetch(this.API_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query: this.query(client.chain.id, asset) }),
-      });
+      if (!this.scheduledChains.has(chainId)) {
+        this.scheduledChains.add(chainId);
+        queueMicrotask(() => void this.flush(chainId));
+      }
+    });
+  }
 
-      const data = (await response.json()) as {
-        data: { assets: { items: { address: Address; priceUsd: number }[] } };
-      };
+  private async flush(chainId: number) {
+    const requests = this.pendingRequests.get(chainId) ?? [];
+    this.pendingRequests.delete(chainId);
+    this.scheduledChains.delete(chainId);
 
-      const items = data.data.assets.items;
+    if (requests.length === 0) return;
 
-      const priceUsd = items.find((item) => item.address === asset)?.priceUsd ?? null;
+    const uniqueAssets = [
+      ...new Map(requests.map((request) => [this.key(request.asset), request.asset])).values(),
+    ];
+    const prices = await this.fetchPrices(chainId, uniqueAssets);
 
-      return priceUsd ?? undefined;
-    } catch (error) {
-      console.error(error);
-      return undefined;
+    for (const request of requests) {
+      request.resolve(prices.get(this.key(request.asset)));
     }
   }
 
-  private async initialize() {
-    const initilizationQuery = `
-      query {
-        chains{
-            id
+  private async fetchPrices(chainId: number, assets: Address[]) {
+    const prices = new Map<string, number>();
+    const chunks = this.chunk(assets, ASSET_BATCH_SIZE);
+
+    await Promise.all(
+      chunks.map(async (chunk) => {
+        try {
+          const response = await fetch(MORPHO_API_GRAPHQL_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              query: this.query(),
+              variables: { chainId, addresses: chunk, first: ASSET_BATCH_SIZE },
+            }),
+          });
+
+          if (!response.ok) return;
+
+          const data = (await response.json()) as AssetsPriceResponse;
+
+          if (data.errors?.length) {
+            console.error(data.errors.map((error) => error.message).join("\n"));
+            return;
+          }
+
+          for (const item of data.data?.assets?.items ?? []) {
+            if (item.price?.usd === undefined || item.price.usd === null) continue;
+            prices.set(this.key(item.address), item.price.usd);
+          }
+        } catch (error) {
+          console.error(error);
+        }
+      }),
+    );
+
+    return prices;
+  }
+
+  private query() {
+    return `
+      query PriceAssets($chainId: Int!, $addresses: [String!]!, $first: Int!) {
+        assets(first: $first, where: { chainId_in: [$chainId], address_in: $addresses }) {
+          items {
+            address
+            price {
+              usd
+            }
+          }
         }
       }
-      `;
-
-    try {
-      const response = await fetch(this.API_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query: initilizationQuery }),
-      });
-
-      const data = (await response.json()) as { data: { chains: { id: number }[] } };
-      this.supportedChains = data.data.chains.map((chain) => chain.id);
-      this.initialized = true;
-    } catch (error) {
-      console.error(error);
-    }
+    `;
   }
 
-  private query(chainId: number, asset: Address) {
-    return `
-    query {
-        assets(where: { address_in: ["${asset}"], chainId_in: [${chainId}]} ) {
-            items {
-                address
-                priceUsd
-            }
-        }
+  private chunk<T>(items: T[], size: number) {
+    const chunks: T[][] = [];
+
+    for (let i = 0; i < items.length; i += size) {
+      chunks.push(items.slice(i, i + size));
     }
-    `;
+
+    return chunks;
+  }
+
+  private key(address: Address) {
+    return address.toLowerCase();
   }
 }

--- a/apps/pricers/test/vitest/morphoApi.test.ts
+++ b/apps/pricers/test/vitest/morphoApi.test.ts
@@ -1,17 +1,106 @@
 import { randomAddress } from "@morpho-org/test";
-import { describe, expect } from "vitest";
+import type { Account, Address, Chain, Client, Transport } from "viem";
+import { mainnet } from "viem/chains";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MorphoApi } from "../../src";
-import { WBTC, USDC, USDC_BASE } from "../constants.js";
-import { test } from "../setup.js";
+import { WBTC, USDC } from "../constants.js";
+
+interface PriceAssetsRequest {
+  query: string;
+  variables: {
+    chainId: number;
+    addresses: Address[];
+    first: number;
+  };
+}
 
 describe("morpho api pricer", () => {
-  const pricer = new MorphoApi();
+  const client = { chain: mainnet } as Client<Transport, Chain, Account>;
 
-  test.sequential("should test price", async ({ client }) => {
-    expect((await pricer.price(client, USDC)) - 1).toBeLessThan(0.1);
-    expect(await pricer.price(client, USDC_BASE)).toBeUndefined();
-    expect(await pricer.price(client, WBTC)).toBeGreaterThan(0);
-    expect(await pricer.price(client, randomAddress(1))).toBeUndefined();
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should batch same-chain price requests", async () => {
+    const pricer = new MorphoApi();
+    const unknown = randomAddress(1);
+
+    const fetchMock = vi.fn(
+      async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        const body = JSON.parse(init?.body as string) as PriceAssetsRequest;
+
+        expect(body.query).toContain("PriceAssets");
+        expect(body.query).not.toContain("chains");
+        expect(body.variables).toEqual({
+          chainId: client.chain.id,
+          addresses: [USDC, WBTC, unknown],
+          first: 30,
+        });
+
+        return new Response(
+          JSON.stringify({
+            data: {
+              assets: {
+                items: [
+                  { address: USDC, price: { usd: 1 } },
+                  { address: WBTC, price: { usd: 50_000 } },
+                ],
+              },
+            },
+          }),
+        );
+      },
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const [usdcPrice, wbtcPrice, unknownPrice] = await Promise.all([
+      pricer.price(client, USDC),
+      pricer.price(client, WBTC),
+      pricer.price(client, unknown),
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(usdcPrice).toBe(1);
+    expect(wbtcPrice).toBe(50_000);
+    expect(unknownPrice).toBeUndefined();
+  });
+
+  it("should split price requests into chunks of 30", async () => {
+    const pricer = new MorphoApi();
+    const addresses = Array.from({ length: 31 }, (_, index) => randomAddress(index + 1));
+    const requestedChunks: Address[][] = [];
+
+    const fetchMock = vi.fn(
+      async (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+        const body = JSON.parse(init?.body as string) as PriceAssetsRequest;
+        requestedChunks.push(body.variables.addresses);
+
+        expect(body.variables.chainId).toBe(client.chain.id);
+        expect(body.variables.first).toBe(30);
+
+        return new Response(
+          JSON.stringify({
+            data: {
+              assets: {
+                items: body.variables.addresses.map((address) => ({
+                  address,
+                  price: { usd: 1 },
+                })),
+              },
+            },
+          }),
+        );
+      },
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const prices = await Promise.all(addresses.map((address) => pricer.price(client, address)));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requestedChunks.map((chunk) => chunk.length)).toEqual([30, 1]);
+    expect(prices.every((price) => price === 1)).toBe(true);
   });
 });


### PR DESCRIPTION
Updates Morpho GraphQL usage to https://api.morpho.org/graphql and centralizes the endpoint in config.

Refactors the Morpho API pricer to coalesce same-chain requests, batch addresses in chunks of 30, and read price { usd } instead of deprecated priceUsd.

Renames the listed-vault helper to fetchListedVaults and updates test mocks for the new API shape.

Validated with pnpm build and pnpm exec vitest run apps/pricers/test/vitest/morphoApi.test.ts; broader fork-backed tests were blocked locally by the default RPC rate limit.